### PR TITLE
Fail make script build if signing is ON, but fails

### DIFF
--- a/publish/cli/make-bin-win32.sh
+++ b/publish/cli/make-bin-win32.sh
@@ -76,7 +76,14 @@ if [ -z "$LMS_NO_SIGN" ]; then
 
     # Try to sign the binary
     if [[ -n "${DIST_DIR}" ]] && [[ -n "${EXE_NAME}" ]]; then
-        smctl sign --keypair-alias="${WINDOWS_DIGICERT_KEYPAIR_ALIAS}" --input "${DIST_DIR}/${EXE_NAME}"
+        echo "Attempting to sign '${DIST_DIR}/${EXE_NAME}'..."
+        output=$(smctl sign --keypair-alias="${WINDOWS_DIGICERT_KEYPAIR_ALIAS}" --input "${DIST_DIR}/${EXE_NAME}" -v)
+        if [ $? -ne 0 ] || [[ ! $output == *"SUCCESSFUL"* ]]; then
+            echo "Error: Failed to sign the binary at '${DIST_DIR}/${EXE_NAME}' with output: $output"
+            echo "Signing FAILED"
+            exit 1
+        fi
+        echo "Signing was SUCCESSFUL"
     else
         echo "Warning: DIST_DIR or EXE_NAME is not set - To skip signing, set LMS_NO_SIGN=true"
         exit 1
@@ -84,3 +91,4 @@ if [ -z "$LMS_NO_SIGN" ]; then
 else
   echo "LMS_NO_SIGN is set, signing skipped."
 fi
+


### PR DESCRIPTION
Will now get this output on fail:
```
Error: Failed to sign the binary at './dist/lms.exe' with output: 
Command :
<command>
Error :
<error info>

signCommand command for file ./dist/lms.exe FAILED
Signing FAILED
npm ERR! ...
```
This output on success:
```
Attempting to sign './dist/lms.exe'...
Signing was SUCCESSFUL
```

Instead of what was previously a "silent" failure that wouldn't cause an npm ERR