### PR TITLE
Fix signtool remove command invocation (//s to /s)

### DIFF
--- a/publish/cli/make-bin-win32.ps1
+++ b/publish/cli/make-bin-win32.ps1
@@ -64,7 +64,7 @@ Copy-Item -Path "${NODE_DIR}/node.exe" -Destination "${DIST_DIR}/${EXE_NAME}"
 
 if (-Not $env:LMS_NO_SIGN) {
     # Remove the signature
-    & signtool remove "//s" "${DIST_DIR}/${EXE_NAME}"
+    & signtool remove /s "${DIST_DIR}/${EXE_NAME}"
 }
 
 # Inject the blob into the copied binary


### PR DESCRIPTION
This was an artifact of the deprecated bash script that does not work in powershell.