### PR TITLE
Fix powershell reading of .env file to specify code-signing environment variables

### DIFF
--- a/publish/cli/make-bin-win32.ps1
+++ b/publish/cli/make-bin-win32.ps1
@@ -31,8 +31,16 @@ function Load-EnvFromAncestors {
         if (Test-Path $envPath) {
             Write-Host "Loading .env from $currentDir"
             Get-Content $envPath | ForEach-Object {
-                $key, $value = $_.Split('=', 2)
-                Set-Variable -Name $key -Value $value -Scope Global
+                # ignore lines that don't have the expected X=Y format
+                if ($_ -and $_.Contains('=')) {
+                    $key, $value = $_.Split('=', 2)
+                    # Remove single quotes from the value if present
+                    $value = $value.Trim("'")
+                    # Set environment variable for the current process
+                    [System.Environment]::SetEnvironmentVariable($key, $value, [System.EnvironmentVariableTarget]::Process)
+                    # Output the environment variable and its value
+                    Write-Output "Setting environment variable: '$key'"
+                }
             }
         }
         $currentDir = Split-Path $currentDir -Parent


### PR DESCRIPTION
Fix to `make-bin-win32.ps1` so that it can successfully read a `.env` file of the format:
```
ENV_VAR1='value1'
ENV_VAR2='value2'
```
This was the previous, working behavior of the `make-bin-win32.sh` file, but broke when migrated to powershell in https://github.com/lmstudio-ai/lmstudio.js/commit/e4461436be0a0c1f9e9584d7dd46d45d4bf60f8f