### PR TITLE
Allow using superjson in transport

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
   "typescript.tsserver.experimental.enableProjectDiagnostics": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": "explicit",
-    "source.fixAll.eslint": "explicit"
+    "source.organizeImports": "always",
+    "source.fixAll.eslint": "always"
   },
   "editor.rulers": [100],
   "cSpell.words": [
@@ -20,6 +20,7 @@
     "proxying",
     "Rpcs",
     "Streamable",
+    "superjson",
     "uncategorized",
     "unsubscriber"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8134,6 +8134,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "dev": true,
@@ -11437,6 +11451,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-wsl": {
@@ -18537,6 +18562,17 @@
         "node": ">= 8.0"
       }
     },
+    "node_modules/superjson": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.13.3.tgz",
+      "integrity": "sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "license": "MIT",
@@ -20697,6 +20733,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@lmstudio/lms-common": "^0.6.0",
+        "superjson": "^1.13.3",
         "zod": "^3.22.4"
       },
       "devDependencies": {

--- a/packages/lms-common/src/LazySignal.ts
+++ b/packages/lms-common/src/LazySignal.ts
@@ -110,10 +110,10 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
       derive(),
       setDownstream => {
         const unsubscriber = sourceSignals.map(signal =>
-          signal.subscribeFull((_values, _patches, tags) => {
+          signal.subscribe(() => {
             const value = derive();
             if (isAvailable(value)) {
-              setDownstream(value, tags);
+              setDownstream(value);
             }
           }),
         );

--- a/packages/lms-communication-client/src/ClientPort.ts
+++ b/packages/lms-communication-client/src/ClientPort.ts
@@ -19,7 +19,7 @@ import type {
   RpcEndpoint,
   ServerToClientMessage,
 } from "@lmstudio/lms-communication";
-import { Channel } from "@lmstudio/lms-communication";
+import { Channel, deserialize, serialize } from "@lmstudio/lms-communication";
 import {
   type ChannelEndpointsSpecBase,
   type RpcEndpointsSpecBase,
@@ -172,11 +172,12 @@ export class ClientPort<
       );
       return;
     }
-    const parsed = openChannel.endpoint.toClientPacket.safeParse(message.message);
+    const deserializedMessage = deserialize(openChannel.endpoint.serialization, message.message);
+    const parsed = openChannel.endpoint.toClientPacket.safeParse(deserializedMessage);
     if (!parsed.success) {
       this.communicationWarning(text`
         Received invalid message for channel: endpointName = ${openChannel.endpoint.name}, message =
-        ${message.message}. Zod error:
+        ${deserializedMessage}. Zod error:
 
         ${Validator.prettyPrintZod("message", parsed.error)}
       `);
@@ -233,11 +234,12 @@ export class ClientPort<
       this.communicationWarning(`Received rpcResult for unknown rpc, callId = ${message.callId}`);
       return;
     }
-    const parsed = ongoingRpc.endpoint.returns.safeParse(message.result);
+    const deserializedResult = deserialize(ongoingRpc.endpoint.serialization, message.result);
+    const parsed = ongoingRpc.endpoint.returns.safeParse(deserializedResult);
     if (!parsed.success) {
       this.communicationWarning(text`
         Received invalid result for rpc, endpointName = ${ongoingRpc.endpoint.name}, result =
-        ${message.result}. Zod error:
+        ${deserializedResult}. Zod error:
 
         ${Validator.prettyPrintZod("result", parsed.error)}
       `);
@@ -273,14 +275,16 @@ export class ClientPort<
       // and is especially prevalent when React StrictMode is enabled, because components are
       // rendered twice where signals are oftentimes subscribed and then unsubscribed immediately
       // after.
-      this.logger.debugText`
-        Received signalUpdate for unknown signal, subscribeId = ${message.subscribeId}. This is
-        likely caused by the update being sent after the signal was unsubscribed. (Usually not an
-        error and can be safely ignored unless some signal is not updating.)
-      `;
+      // this.logger.debugText`
+      //   Received signalUpdate for unknown signal, subscribeId = ${message.subscribeId}. This is
+      //   likely caused by the update being sent after the signal was unsubscribed. (Usually not an
+      //   error and can be safely ignored unless some signal is not updating.)
+      // `;
       return;
     }
-    const patches = message.patches;
+    const patches = message.patches.map(patch =>
+      deserialize(openSignalSubscription.endpoint.serialization, patch),
+    );
     const beforeValue = openSignalSubscription.getValue();
     let afterValue: any;
     try {
@@ -315,7 +319,7 @@ export class ClientPort<
       return;
     }
     // Don't use the parsed value, as it loses the substructure identities
-    openSignalSubscription.receivedPatches(afterValue, message.patches, message.tags);
+    openSignalSubscription.receivedPatches(afterValue, patches, message.tags);
   }
 
   private receivedSignalError(message: ServerToClientMessage & { type: "signalError" }) {
@@ -347,14 +351,16 @@ export class ClientPort<
       // and is especially prevalent when React StrictMode is enabled, because components are
       // rendered twice where signals are oftentimes subscribed and then unsubscribed immediately
       // after.
-      this.logger.debugText`
-        Received writableSignalUpdate for unknown signal, subscribeId = ${message.subscribeId}. This
-        is likely caused by the update being sent after the signal was unsubscribed. (Usually not an
-        error and can be safely ignored unless some signal is not updating.)
-      `;
+      // this.logger.debugText`
+      //   Received writableSignalUpdate for unknown signal, subscribeId = ${message.subscribeId}. This
+      //   is likely caused by the update being sent after the signal was unsubscribed. (Usually not an
+      //   error and can be safely ignored unless some signal is not updating.)
+      // `;
       return;
     }
-    const patches = message.patches;
+    const patches = message.patches.map(patch =>
+      deserialize(openSignalSubscription.endpoint.serialization, patch),
+    );
     const beforeValue = openSignalSubscription.getValue();
     let afterValue: any;
     try {
@@ -500,6 +506,7 @@ export class ClientPort<
       throw new Error(`No Rpc endpoint with name ${endpointName}`);
     }
     const parameter = endpoint.parameter.parse(param);
+    const serializedParameter = serialize(endpoint.serialization, parameter);
 
     const callId = this.nextChannelId;
     this.nextChannelId++;
@@ -518,7 +525,7 @@ export class ClientPort<
       type: "rpcCall",
       endpoint: endpointName,
       callId,
-      parameter,
+      parameter: serializedParameter,
     });
 
     this.updateOpenCommunicationsCount();
@@ -539,6 +546,7 @@ export class ClientPort<
       throw new Error(`No channel endpoint with name ${endpointName}`);
     }
     const creationParameter = channelEndpoint.creationParameter.parse(param);
+    const serializedCreationParameter = serialize(channelEndpoint.serialization, creationParameter);
 
     const channelId = this.nextChannelId;
     this.nextChannelId++;
@@ -547,7 +555,7 @@ export class ClientPort<
       type: "channelCreate",
       endpoint: endpointName,
       channelId,
-      creationParameter,
+      creationParameter: serializedCreationParameter,
     });
 
     stack = stack ?? getCurrentStack(1);
@@ -556,11 +564,12 @@ export class ClientPort<
       endpoint: channelEndpoint,
       stack,
       ...Channel.create(packet => {
-        const result = channelEndpoint.toServerPacket.parse(packet);
+        const parsed = channelEndpoint.toServerPacket.parse(packet);
+        const serializedMessage = serialize(channelEndpoint.serialization, parsed);
         this.transport.send({
           type: "channelSend",
           channelId,
-          message: result,
+          message: serializedMessage,
         });
       }),
     };
@@ -586,6 +595,7 @@ export class ClientPort<
       throw new Error(`No signal endpoint with name ${endpointName}`);
     }
     const creationParameter = signalEndpoint.creationParameter.parse(param);
+    const serializedCreationParameter = serialize(signalEndpoint.serialization, creationParameter);
 
     stack = stack ?? getCurrentStack(1);
 
@@ -596,7 +606,7 @@ export class ClientPort<
         type: "signalSubscribe",
         endpoint: endpointName,
         subscribeId,
-        creationParameter,
+        creationParameter: serializedCreationParameter,
       });
       this.openSignalSubscriptions.set(subscribeId, {
         endpoint: signalEndpoint,
@@ -631,6 +641,7 @@ export class ClientPort<
       throw new Error(`No writable signal endpoint with name ${endpointName}`);
     }
     const creationParameter = signalEndpoint.creationParameter.parse(param);
+    const serializedCreationParameter = serialize(signalEndpoint.serialization, creationParameter);
 
     stack = stack ?? getCurrentStack(1);
 
@@ -647,7 +658,7 @@ export class ClientPort<
       this.transport.send({
         type: "writableSignalUpdate",
         subscribeId: currentSubscribeId as any,
-        patches,
+        patches: patches.map(patch => serialize(signalEndpoint.serialization, patch)),
         tags,
       });
       return true;
@@ -661,7 +672,7 @@ export class ClientPort<
         type: "writableSignalSubscribe",
         endpoint: endpointName,
         subscribeId,
-        creationParameter,
+        creationParameter: serializedCreationParameter,
       });
       this.openWritableSignalSubscriptions.set(subscribeId, {
         endpoint: signalEndpoint,

--- a/packages/lms-communication/package.json
+++ b/packages/lms-communication/package.json
@@ -11,6 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@lmstudio/lms-common": "^0.6.0",
+    "superjson": "^1.13.3",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/lms-communication/src/BackendInterface.ts
+++ b/packages/lms-communication/src/BackendInterface.ts
@@ -2,6 +2,7 @@
 import { type NotAvailable, type Setter, type SignalLike } from "@lmstudio/lms-common";
 import { type z, type ZodType } from "zod";
 import type { Channel } from "./Channel";
+import { type SerializationType } from "./serialization";
 
 export type RpcEndpointHandler<TContext = any, TParameter = any, TReturns = any> = (
   ctx: TContext,
@@ -41,6 +42,7 @@ export interface RpcEndpoint {
   name: string;
   parameter: z.ZodType;
   returns: z.ZodType;
+  serialization: SerializationType;
   handler: RpcEndpointHandler | null;
 }
 
@@ -49,6 +51,7 @@ export interface ChannelEndpoint {
   creationParameter: z.ZodType;
   toServerPacket: z.ZodType;
   toClientPacket: z.ZodType;
+  serialization: SerializationType;
   handler: ChannelEndpointHandler | null;
 }
 
@@ -56,6 +59,7 @@ export interface SignalEndpoint {
   name: string;
   creationParameter: z.ZodType;
   signalData: z.ZodType;
+  serialization: SerializationType;
   handler: SignalEndpointHandler | null;
 }
 
@@ -63,6 +67,7 @@ export interface WritableSignalEndpoint {
   name: string;
   creationParameter: z.ZodType;
   signalData: z.ZodType;
+  serialization: SerializationType;
   handler: WritableSignalEndpointHandler | null;
 }
 
@@ -147,9 +152,11 @@ export class BackendInterface<
     {
       parameter,
       returns,
+      serialization = "raw",
     }: {
       parameter: TParametersZod;
       returns: TReturnsZod;
+      serialization?: SerializationType;
     },
   ): BackendInterface<
     TContext,
@@ -169,6 +176,7 @@ export class BackendInterface<
       name: endpointName,
       parameter,
       returns,
+      serialization,
       handler: null,
     });
     return this;
@@ -185,10 +193,12 @@ export class BackendInterface<
       creationParameter,
       toServerPacket,
       toClientPacket,
+      serialization = "raw",
     }: {
       creationParameter: TCreationParameterZod;
       toServerPacket: TToServerPacketZod;
       toClientPacket: TToClientPacketZod;
+      serialization?: SerializationType;
     },
   ): BackendInterface<
     TContext,
@@ -210,6 +220,7 @@ export class BackendInterface<
       creationParameter,
       toServerPacket,
       toClientPacket,
+      serialization,
       handler: null,
     });
     return this;
@@ -224,9 +235,11 @@ export class BackendInterface<
     {
       creationParameter,
       signalData,
+      serialization = "raw",
     }: {
       creationParameter: TCreationParameterZod;
       signalData: TSignalDataZod;
+      serialization?: SerializationType;
     },
   ): BackendInterface<
     TContext,
@@ -246,6 +259,7 @@ export class BackendInterface<
       name: endpointName,
       creationParameter,
       signalData,
+      serialization,
       handler: null,
     });
     return this;
@@ -260,9 +274,11 @@ export class BackendInterface<
     {
       creationParameter,
       signalData,
+      serialization = "raw",
     }: {
       creationParameter: TCreationParameterZod;
       signalData: TSignalDataZod;
+      serialization?: SerializationType;
     },
   ): BackendInterface<
     TContext,
@@ -282,6 +298,7 @@ export class BackendInterface<
       name: endpointName,
       creationParameter,
       signalData,
+      serialization,
       handler: null,
     });
     return this;

--- a/packages/lms-communication/src/Transport.ts
+++ b/packages/lms-communication/src/Transport.ts
@@ -1,6 +1,7 @@
 import { type LoggerInterface } from "@lmstudio/lms-common";
 import { serializedLMSExtendedErrorSchema } from "@lmstudio/lms-shared-types";
 import { z } from "zod";
+import { serializedOpaqueSchema } from "./serialization";
 
 const clientToServerMessageSchema = z.discriminatedUnion("type", [
   // Communication
@@ -17,12 +18,12 @@ const clientToServerMessageSchema = z.discriminatedUnion("type", [
     type: z.literal("channelCreate"),
     endpoint: z.string(),
     channelId: z.number(),
-    creationParameter: z.any(),
+    creationParameter: serializedOpaqueSchema,
   }),
   z.object({
     type: z.literal("channelSend"),
     channelId: z.number(),
-    message: z.any(),
+    message: serializedOpaqueSchema,
     ackId: z.number().optional(),
   }),
   z.object({
@@ -36,13 +37,13 @@ const clientToServerMessageSchema = z.discriminatedUnion("type", [
     type: z.literal("rpcCall"),
     endpoint: z.string(),
     callId: z.number(),
-    parameter: z.any(),
+    parameter: serializedOpaqueSchema,
   }),
 
   // Readonly signal
   z.object({
     type: z.literal("signalSubscribe"),
-    creationParameter: z.any(),
+    creationParameter: serializedOpaqueSchema,
     endpoint: z.string(),
     subscribeId: z.number(),
   }),
@@ -54,7 +55,7 @@ const clientToServerMessageSchema = z.discriminatedUnion("type", [
   // Writable signal
   z.object({
     type: z.literal("writableSignalSubscribe"),
-    creationParameter: z.any(),
+    creationParameter: serializedOpaqueSchema,
     endpoint: z.string(),
     subscribeId: z.number(),
   }),
@@ -65,7 +66,7 @@ const clientToServerMessageSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("writableSignalUpdate"),
     subscribeId: z.number(),
-    patches: z.array(z.any()),
+    patches: z.array(serializedOpaqueSchema),
     tags: z.array(z.string()),
   }),
 ]);
@@ -86,7 +87,7 @@ const serverToClientMessageSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("channelSend"),
     channelId: z.number(),
-    message: z.any(),
+    message: serializedOpaqueSchema,
     ackId: z.number().optional(),
   }),
   z.object({
@@ -108,7 +109,7 @@ const serverToClientMessageSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("rpcResult"),
     callId: z.number(),
-    result: z.any(),
+    result: serializedOpaqueSchema,
   }),
   z.object({
     type: z.literal("rpcError"),
@@ -120,7 +121,7 @@ const serverToClientMessageSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("signalUpdate"),
     subscribeId: z.number(),
-    patches: z.array(z.any()),
+    patches: z.array(serializedOpaqueSchema),
     tags: z.array(z.string()),
   }),
   z.object({
@@ -133,7 +134,7 @@ const serverToClientMessageSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("writableSignalUpdate"),
     subscribeId: z.number(),
-    patches: z.array(z.any()),
+    patches: z.array(serializedOpaqueSchema),
     tags: z.array(z.string()),
   }),
   z.object({

--- a/packages/lms-communication/src/index.ts
+++ b/packages/lms-communication/src/index.ts
@@ -9,6 +9,13 @@ export {
   WritableSignalEndpointsSpecBase,
 } from "./BackendInterface";
 export { Channel } from "./Channel";
+export {
+  SerializationType,
+  SerializedOpaque,
+  deserialize,
+  serialize,
+  serializedOpaqueSchema,
+} from "./serialization";
 export { KEEP_ALIVE_INTERVAL, KEEP_ALIVE_TIMEOUT } from "./timeoutConstants";
 export {
   ClientToServerMessage,

--- a/packages/lms-communication/src/serialization.ts
+++ b/packages/lms-communication/src/serialization.ts
@@ -1,0 +1,43 @@
+import { deserialize as superJsonDeserialize, serialize as superJsonSerialize } from "superjson";
+import { z, type ZodSchema } from "zod";
+
+/**
+ * Type of serialization:
+ *
+ * Raw: JSON.stringify and JSON.parse
+ * Superjson: SuperJSON.serialize and SuperJSON.deserialize
+ */
+export type SerializationType = "raw" | "superjson";
+
+const serializedOpaqueSymbol = Symbol("SerializedOpaque");
+
+/**
+ * Opaque type that represents a serialized value. The representation here is not accurate and is
+ * only used to prevent accidental reading/writing of the opaque value.
+ */
+export type SerializedOpaque<T> = {
+  [serializedOpaqueSymbol]: T;
+};
+
+/**
+ * Serialize a value to another value using the specified serialization type.
+ */
+export function serialize<TData>(type: SerializationType, value: TData): SerializedOpaque<TData> {
+  switch (type) {
+    case "raw":
+      return value as SerializedOpaque<TData>;
+    case "superjson":
+      return superJsonSerialize(value) as unknown as SerializedOpaque<TData>;
+  }
+}
+
+export function deserialize<TData>(type: SerializationType, value: SerializedOpaque<TData>): TData {
+  switch (type) {
+    case "raw":
+      return value as TData;
+    case "superjson":
+      return superJsonDeserialize(value as unknown as any) as TData;
+  }
+}
+
+export const serializedOpaqueSchema = z.any() as ZodSchema<SerializedOpaque<any>>;


### PR DESCRIPTION
When defining a endpoint, one can optionally provide a "serialization" field. By default, it is "raw" i.e. only json serialization is used.
However, when "superjson" is provided, everything that is transmitted will be serialized with superjson, which means objects like Set, Map, Date, etc. can be transmitted without problem.

Though, superjson is not fast, so it is not used by defualt.