### PR TITLE
Export retrieval API types

### DIFF
--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -7,12 +7,12 @@ export {
   DiagnosticsLogEvent,
   DiagnosticsLogEventData,
   diagnosticsLogEventDataSchema,
-  diagnosticsLogEventSchema
+  diagnosticsLogEventSchema,
 } from "./diagnostics/DiagnosticsLogEvent";
 export { DownloadedModel, downloadedModelSchema } from "./DownloadedModel";
 export {
   EmbeddingLoadModelConfig,
-  embeddingLoadModelConfigSchema
+  embeddingLoadModelConfigSchema,
 } from "./embedding/EmbeddingLoadModelConfig";
 export {
   attachSerializedErrorData,
@@ -22,7 +22,7 @@ export {
   recreateSerializedError,
   SerializedLMSExtendedError,
   serializedLMSExtendedErrorSchema,
-  serializeError
+  serializeError,
 } from "./Error";
 export {
   KVConfig,
@@ -34,11 +34,11 @@ export {
   KVConfigStack,
   KVConfigStackLayer,
   kvConfigStackLayerSchema,
-  kvConfigStackSchema
+  kvConfigStackSchema,
 } from "./KVConfig";
 export {
   LLMApplyPromptTemplateOpts,
-  llmApplyPromptTemplateOptsSchema
+  llmApplyPromptTemplateOptsSchema,
 } from "./llm/LLMApplyPromptTemplateOpts";
 export {
   LLMChatHistory,
@@ -56,7 +56,7 @@ export {
   LLMContext,
   llmContextSchema,
   LLMConversationContextInput,
-  llmConversationContextInputSchema
+  llmConversationContextInputSchema,
 } from "./llm/LLMChatHistory";
 export {
   LLMContextReference,
@@ -64,7 +64,7 @@ export {
   llmContextReferenceJsonFileSchema,
   llmContextReferenceSchema,
   LLMContextReferenceYamlFile,
-  llmContextReferenceYamlFileSchema
+  llmContextReferenceYamlFileSchema,
 } from "./llm/LLMContextReference";
 export {
   LLMLlamaAccelerationOffloadRatio,
@@ -72,7 +72,7 @@ export {
   LLMLlamaAccelerationSetting,
   llmLlamaAccelerationSettingSchema,
   LLMLoadModelConfig,
-  llmLoadModelConfigSchema
+  llmLoadModelConfigSchema,
 } from "./llm/LLMLoadModelConfig";
 export {
   LLMContextOverflowPolicy,
@@ -84,7 +84,7 @@ export {
   LLMLlamaSingleLogitBiasModification,
   llmLlamaSingleLogitBiasModificationSchema,
   LLMPredictionConfig,
-  llmPredictionConfigSchema
+  llmPredictionConfigSchema,
 } from "./llm/LLMPredictionConfig";
 export {
   LLMGenInfo,
@@ -92,7 +92,7 @@ export {
   LLMPredictionStats,
   llmPredictionStatsSchema,
   LLMPredictionStopReason,
-  llmPredictionStopReasonSchema
+  llmPredictionStopReasonSchema,
 } from "./llm/LLMPredictionStats";
 export {
   LLMJinjaPromptTemplate,
@@ -102,17 +102,17 @@ export {
   LLMPromptTemplate,
   llmPromptTemplateSchema,
   LLMPromptTemplateType,
-  llmPromptTemplateTypeSchema
+  llmPromptTemplateTypeSchema,
 } from "./llm/LLMPromptTemplate";
 export {
   LLMStructuredPredictionSetting,
-  llmStructuredPredictionSettingSchema
+  llmStructuredPredictionSettingSchema,
 } from "./llm/LLMStructuredPredictionSetting";
 export {
   GetModelOpts,
   getModelOptsSchema,
   ResolvedGetModelOpts,
-  resolvedGetModelOptsSchema
+  resolvedGetModelOptsSchema,
 } from "./llm/processor/Processor";
 export {
   ProcessorInputContext,
@@ -124,7 +124,7 @@ export {
   ProcessorInputMessage,
   ProcessorInputMessageRole,
   processorInputMessageRoleSchema,
-  processorInputMessageSchema
+  processorInputMessageSchema,
 } from "./llm/processor/ProcessorInput";
 export {
   ProcessorUpdate,
@@ -143,7 +143,7 @@ export {
   ProcessorUpdateStatusCreate,
   processorUpdateStatusCreateSchema,
   ProcessorUpdateStatusUpdate,
-  processorUpdateStatusUpdateSchema
+  processorUpdateStatusUpdateSchema,
 } from "./llm/processor/ProcessorUpdate";
 export {
   BlockLocation,
@@ -166,7 +166,7 @@ export {
   StatusStepState,
   statusStepStateSchema,
   StatusStepStatus,
-  statusStepStatusSchema
+  statusStepStatusSchema,
 } from "./llm/processor/PromptPreprocessorUpdate";
 export { ModelDescriptor, modelDescriptorSchema } from "./ModelDescriptor";
 export { ModelDomainType, modelDomainTypeSchema } from "./ModelDomainType";
@@ -174,7 +174,7 @@ export {
   ModelQuery,
   modelQuerySchema,
   ModelSpecifier,
-  modelSpecifierSchema
+  modelSpecifierSchema,
 } from "./ModelSpecifier";
 export { reasonableKeyStringSchema } from "./reasonable";
 export { Chunk, chunkSchema } from "./retrieval/Chunk";
@@ -186,7 +186,6 @@ export {
   AcceleratorType,
   acceleratorTypeSchema,
   Runtime,
-  runtimeSchema
+  runtimeSchema,
 } from "./Runtime";
 export { VirtualModelManifest, virtualModelManifestSchema } from "./VirtualModelManifest";
-

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -7,12 +7,12 @@ export {
   DiagnosticsLogEvent,
   DiagnosticsLogEventData,
   diagnosticsLogEventDataSchema,
-  diagnosticsLogEventSchema,
+  diagnosticsLogEventSchema
 } from "./diagnostics/DiagnosticsLogEvent";
 export { DownloadedModel, downloadedModelSchema } from "./DownloadedModel";
 export {
   EmbeddingLoadModelConfig,
-  embeddingLoadModelConfigSchema,
+  embeddingLoadModelConfigSchema
 } from "./embedding/EmbeddingLoadModelConfig";
 export {
   attachSerializedErrorData,
@@ -22,7 +22,7 @@ export {
   recreateSerializedError,
   SerializedLMSExtendedError,
   serializedLMSExtendedErrorSchema,
-  serializeError,
+  serializeError
 } from "./Error";
 export {
   KVConfig,
@@ -34,11 +34,11 @@ export {
   KVConfigStack,
   KVConfigStackLayer,
   kvConfigStackLayerSchema,
-  kvConfigStackSchema,
+  kvConfigStackSchema
 } from "./KVConfig";
 export {
   LLMApplyPromptTemplateOpts,
-  llmApplyPromptTemplateOptsSchema,
+  llmApplyPromptTemplateOptsSchema
 } from "./llm/LLMApplyPromptTemplateOpts";
 export {
   LLMChatHistory,
@@ -56,7 +56,7 @@ export {
   LLMContext,
   llmContextSchema,
   LLMConversationContextInput,
-  llmConversationContextInputSchema,
+  llmConversationContextInputSchema
 } from "./llm/LLMChatHistory";
 export {
   LLMContextReference,
@@ -64,7 +64,7 @@ export {
   llmContextReferenceJsonFileSchema,
   llmContextReferenceSchema,
   LLMContextReferenceYamlFile,
-  llmContextReferenceYamlFileSchema,
+  llmContextReferenceYamlFileSchema
 } from "./llm/LLMContextReference";
 export {
   LLMLlamaAccelerationOffloadRatio,
@@ -72,7 +72,7 @@ export {
   LLMLlamaAccelerationSetting,
   llmLlamaAccelerationSettingSchema,
   LLMLoadModelConfig,
-  llmLoadModelConfigSchema,
+  llmLoadModelConfigSchema
 } from "./llm/LLMLoadModelConfig";
 export {
   LLMContextOverflowPolicy,
@@ -84,7 +84,7 @@ export {
   LLMLlamaSingleLogitBiasModification,
   llmLlamaSingleLogitBiasModificationSchema,
   LLMPredictionConfig,
-  llmPredictionConfigSchema,
+  llmPredictionConfigSchema
 } from "./llm/LLMPredictionConfig";
 export {
   LLMGenInfo,
@@ -92,7 +92,7 @@ export {
   LLMPredictionStats,
   llmPredictionStatsSchema,
   LLMPredictionStopReason,
-  llmPredictionStopReasonSchema,
+  llmPredictionStopReasonSchema
 } from "./llm/LLMPredictionStats";
 export {
   LLMJinjaPromptTemplate,
@@ -102,17 +102,17 @@ export {
   LLMPromptTemplate,
   llmPromptTemplateSchema,
   LLMPromptTemplateType,
-  llmPromptTemplateTypeSchema,
+  llmPromptTemplateTypeSchema
 } from "./llm/LLMPromptTemplate";
 export {
   LLMStructuredPredictionSetting,
-  llmStructuredPredictionSettingSchema,
+  llmStructuredPredictionSettingSchema
 } from "./llm/LLMStructuredPredictionSetting";
 export {
   GetModelOpts,
   getModelOptsSchema,
   ResolvedGetModelOpts,
-  resolvedGetModelOptsSchema,
+  resolvedGetModelOptsSchema
 } from "./llm/processor/Processor";
 export {
   ProcessorInputContext,
@@ -124,7 +124,7 @@ export {
   ProcessorInputMessage,
   ProcessorInputMessageRole,
   processorInputMessageRoleSchema,
-  processorInputMessageSchema,
+  processorInputMessageSchema
 } from "./llm/processor/ProcessorInput";
 export {
   ProcessorUpdate,
@@ -143,7 +143,7 @@ export {
   ProcessorUpdateStatusCreate,
   processorUpdateStatusCreateSchema,
   ProcessorUpdateStatusUpdate,
-  processorUpdateStatusUpdateSchema,
+  processorUpdateStatusUpdateSchema
 } from "./llm/processor/ProcessorUpdate";
 export {
   BlockLocation,
@@ -166,7 +166,7 @@ export {
   StatusStepState,
   statusStepStateSchema,
   StatusStepStatus,
-  statusStepStatusSchema,
+  statusStepStatusSchema
 } from "./llm/processor/PromptPreprocessorUpdate";
 export { ModelDescriptor, modelDescriptorSchema } from "./ModelDescriptor";
 export { ModelDomainType, modelDomainTypeSchema } from "./ModelDomainType";
@@ -174,15 +174,19 @@ export {
   ModelQuery,
   modelQuerySchema,
   ModelSpecifier,
-  modelSpecifierSchema,
+  modelSpecifierSchema
 } from "./ModelSpecifier";
 export { reasonableKeyStringSchema } from "./reasonable";
+export { Chunk, chunkSchema } from "./retrieval/Chunk";
+export { ProcessingStep, processingStepSchema } from "./retrieval/ProcessingStep";
+export { RetrievalConfig, retrievalConfigSchema } from "./retrieval/RetrievalConfig";
 export {
   Accelerator,
   acceleratorSchema,
   AcceleratorType,
   acceleratorTypeSchema,
   Runtime,
-  runtimeSchema,
+  runtimeSchema
 } from "./Runtime";
 export { VirtualModelManifest, virtualModelManifestSchema } from "./VirtualModelManifest";
+

--- a/packages/lms-shared-types/src/retrieval/Chunk.ts
+++ b/packages/lms-shared-types/src/retrieval/Chunk.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import {
+  citationSourceSchema,
+  type CitationSource,
+} from "../llm/processor/PromptPreprocessorUpdate";
+
+/**
+ * @public
+ */
+export interface Chunk {
+  content: string;
+  score: number;
+  citation: CitationSource;
+}
+export const chunkSchema = z.object({
+  content: z.string(),
+  score: z.number(),
+  citation: citationSourceSchema,
+});

--- a/packages/lms-shared-types/src/retrieval/ProcessingStep.ts
+++ b/packages/lms-shared-types/src/retrieval/ProcessingStep.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+/**
+ * @public
+ */
+export type ProcessingStep = "querying" | "loading" | "chunking" | "embedding";
+export const processingStepSchema = z.enum(["querying", "loading", "chunking", "embedding"]);

--- a/packages/lms-shared-types/src/retrieval/RetrievalConfig.ts
+++ b/packages/lms-shared-types/src/retrieval/RetrievalConfig.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { type ProcessingStep, processingStepSchema } from "./ProcessingStep";
+
+/**
+ * @public
+ * N.B.: onProgress returns progress as a float taking values from 0 to 1, 1 being completed
+ */
+export interface RetrievalConfig {
+  chunkSize: number;
+  chunkOverlap: number;
+  topK: number;
+  onProgress: (filename: string, step: ProcessingStep, progress: number) => void;
+}
+export const retrievalConfigSchema = z.object({
+  chunkSize: z.number(),
+  chunkOverlap: z.number(),
+  topK: z.number(),
+  onProgress: z.function().args(z.string(), processingStepSchema, z.number()).returns(z.void()),
+});


### PR DESCRIPTION
Adds `Chunk`, `RetrievalConfig`, and `ProcessingStep` types to `lms-shared-types` for the retrieval API. Linter also appeared to go ham on `index.ts`.