### PR TITLE
Fixed zsh bootstrap commands

### DIFF
--- a/packages/lms-lmstudio/src/installCli/darwinOrLinux.ts
+++ b/packages/lms-lmstudio/src/installCli/darwinOrLinux.ts
@@ -40,7 +40,7 @@ const shellInstallationInfo: Array<ShellInstallationInfo> = [
   {
     shellName: "zsh",
     configFileName: ".zshrc",
-    commandToAddComment: "echo '' >> a && echo '# Added by LM Studio CLI tool (lms)' >> ~/.zshrc",
+    commandToAddComment: "echo '' >> ~/.zshrc && echo '# Added by LM Studio CLI tool (lms)' >> ~/.zshrc",
     commandToAddPath: "echo 'export PATH=\"$PATH:<TARGET>\"' >> ~/.zshrc",
   },
   {


### PR DESCRIPTION
The current boostrap command for zsh has a bug in it. The newline intended to be appended to the end of the current .zshrc file is instead added to (or creates) a file named 'a' in the execution directory. Which causes problems when the comment is added to the user's .zshrc file if it didn't already end in a newline. 

This fixes that by making the zsh command consistent with the other shells