### PR TITLE
Ryan/signal kv improvements

### DIFF
--- a/packages/lms-common/src/flattenSignal.ts
+++ b/packages/lms-common/src/flattenSignal.ts
@@ -1,0 +1,37 @@
+import { isAvailable, LazySignal, type NotAvailable } from "./LazySignal";
+import { type SignalLike } from "./Signal";
+
+export function flattenSignalOfSignal<TInner>(
+  rootSignal: SignalLike<SignalLike<TInner | NotAvailable> | NotAvailable>,
+): LazySignal<TInner | NotAvailable> {
+  return LazySignal.createWithoutInitialValue<TInner>(setDownstream => {
+    let unsubscribeInnerSignal: (() => void) | null = null;
+    const subscribeToInnerSignal = (
+      maybeInnerSignal: SignalLike<TInner | NotAvailable> | NotAvailable,
+    ) => {
+      if (!isAvailable(maybeInnerSignal)) {
+        return () => {};
+      }
+      if (unsubscribeInnerSignal !== null) {
+        unsubscribeInnerSignal();
+        unsubscribeInnerSignal = null;
+      }
+      const maybeUpdateDownstream = (value: TInner | NotAvailable) => {
+        if (!isAvailable(value)) {
+          return;
+        }
+        setDownstream(value);
+      };
+      unsubscribeInnerSignal = maybeInnerSignal.subscribe(maybeUpdateDownstream);
+      maybeUpdateDownstream(maybeInnerSignal.get());
+    };
+    const unsubscribeRootSignal = rootSignal.subscribe(subscribeToInnerSignal);
+    subscribeToInnerSignal(rootSignal.get());
+    return () => {
+      if (unsubscribeInnerSignal !== null) {
+        unsubscribeInnerSignal();
+      }
+      unsubscribeRootSignal();
+    };
+  });
+}

--- a/packages/lms-common/src/index.ts
+++ b/packages/lms-common/src/index.ts
@@ -12,6 +12,7 @@ export { Cleaner } from "./Cleaner";
 export { changeErrorStackInPlace, getCurrentStack } from "./errorStack";
 export { Event } from "./Event";
 export { doesFileNameIndicateModel, modelExtensions } from "./fileName";
+export { flattenSignalOfSignal } from "./flattenSignal";
 export { HandledEvent } from "./HandledEvent";
 export { lmsDefaultPorts } from "./lmsDefaultPorts";
 export { makePrettyError, makeTitledPrettyError } from "./makePrettyError";


### PR DESCRIPTION
- Add flattenSignalOfSignal to flatten nested signal
- Fix issue with OWLSignal where multiple writeLoop can overlap
- Improved the performance of OWLSignal by resolving all pending updates at once (instead one update per rounding trip)
- Added fullKeys and effectiveCompareConfig to KVConfigSchematics