### PR TITLE
Separate out server session config

### DIFF
--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -128,6 +128,9 @@ export class LLMDynamicHandle extends DynamicHandle<// prettier-ignore
   private readonly internalKVConfigStack: KVConfigStack = { layers: [] };
 
   /** @internal */
+  private readonly internalIgnoreServerSessionConfig: boolean | undefined = undefined;
+
+  /** @internal */
   private predictInternal(
     modelSpecifier: ModelSpecifier,
     context: LLMContext,
@@ -151,6 +154,7 @@ export class LLMDynamicHandle extends DynamicHandle<// prettier-ignore
         modelSpecifier,
         context,
         predictionConfigStack,
+        ignoreServerSessionConfig: this.internalIgnoreServerSessionConfig,
       },
       message => {
         switch (message.type) {

--- a/packages/lms-client/src/retrieval/RetrievalOpts.ts
+++ b/packages/lms-client/src/retrieval/RetrievalOpts.ts
@@ -6,6 +6,9 @@ import {
 import { z } from "zod";
 import { EmbeddingDynamicHandle } from "../embedding/EmbeddingDynamicHandle";
 
+/**
+ * @public
+ */
 export interface RetrievalCallbacks {
   /**
    * Callback when the list of files to process is available. This list can be shorter than the list

--- a/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
@@ -22,6 +22,7 @@ export function createLlmBackendInterface() {
         modelSpecifier: modelSpecifierSchema,
         context: llmContextSchema,
         predictionConfigStack: kvConfigStackSchema,
+        ignoreServerSessionConfig: z.boolean().optional(),
       }),
       toClientPacket: z.discriminatedUnion("type", [
         z.object({

--- a/packages/lms-kv-config/src/KVConfig.ts
+++ b/packages/lms-kv-config/src/KVConfig.ts
@@ -1012,6 +1012,10 @@ export function singleLayerKVConfigStackOf(
   };
 }
 
+/**
+ * Given a KVConfigStack, add a new layer to the top of the stack. Does not mutate the original
+ * stack.
+ */
 export function addKVConfigToStack(
   stack: KVConfigStack,
   newLayerName: KVConfigLayerName,
@@ -1024,6 +1028,25 @@ export function addKVConfigToStack(
         layerName: newLayerName,
         config: newLayerConfig,
       },
+    ],
+  };
+}
+
+/**
+ * Given a KVConfig, add a new layer to the base of the stack. Does not mutate the original stack.
+ */
+export function addKVConfigToBaseOfStack(
+  stack: KVConfigStack,
+  newLayerName: KVConfigLayerName,
+  newLayerConfig: KVConfig,
+): KVConfigStack {
+  return {
+    layers: [
+      {
+        layerName: newLayerName,
+        config: newLayerConfig,
+      },
+      ...stack.layers,
     ],
   };
 }

--- a/packages/lms-shared-types/src/KVConfig.ts
+++ b/packages/lms-shared-types/src/KVConfig.ts
@@ -35,6 +35,8 @@ export type KVConfigLayerName =
   | "conversationSpecific"
   // Cross-chat global config in chats
   | "conversationGlobal"
+  // Server session specific config
+  | "serverSession"
   // Override provided in the OpenAI http server
   | "httpServerRequestOverride"
   // Override to allow complete mode formatting
@@ -53,6 +55,7 @@ export const kvConfigLayerNameSchema = z.enum([
   "apiOverride",
   "conversationSpecific",
   "conversationGlobal",
+  "serverSession",
   "httpServerRequestOverride",
   "completeModeFormatting",
   "instance",

--- a/packages/lms-shared-types/src/retrieval/RetrievalChunkingMethod.ts
+++ b/packages/lms-shared-types/src/retrieval/RetrievalChunkingMethod.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+/**
+ * @public
+ */
 export type RetrievalChunkingMethod = {
   type: "recursive-v1";
   chunkSize: number;


### PR DESCRIPTION
Makes server config no longer use instance layer. Instead it uses a dedicated server session layer.