### PR TITLE
Export config conversion and various other fixes

### DIFF
--- a/packages/lms-client/src/llm/LLMNamespace.ts
+++ b/packages/lms-client/src/llm/LLMNamespace.ts
@@ -126,7 +126,6 @@ export class LLMNamespace extends ModelNamespace<
             const controller: PreprocessorController = new ProcessingController(
               this.client,
               connector,
-              input,
               message.config,
               /* shouldIncludeInputInHistory */ false,
             );
@@ -243,11 +242,9 @@ export class LLMNamespace extends ModelNamespace<
               message.token,
               taskLogger,
             );
-            const input = ChatMessage.createRaw(message.input, /* mutable */ false);
             const controller: GeneratorController = new ProcessingController(
               this.client,
               connector,
-              input,
               message.config,
               /* shouldIncludeInputInHistory */ true,
             );

--- a/packages/lms-client/src/llm/processing/ProcessingController.ts
+++ b/packages/lms-client/src/llm/processing/ProcessingController.ts
@@ -1,6 +1,6 @@
 import { type SimpleLogger } from "@lmstudio/lms-common";
 import { type LLMPort } from "@lmstudio/lms-external-backend-interfaces";
-import { globalConfigSchematics } from "@lmstudio/lms-kv-config";
+import { kvConfigToLLMPredictionConfig } from "@lmstudio/lms-kv-config";
 import {
   type CitationSource,
   type KVConfig,
@@ -9,7 +9,7 @@ import {
   type ProcessingUpdate,
   type StatusStepState,
 } from "@lmstudio/lms-shared-types";
-import { ChatHistory, type ChatMessage } from "../../ChatHistory";
+import { ChatHistory } from "../../ChatHistory";
 import { type LMStudioClient } from "../../LMStudioClient";
 import { type RetrievalResult, type RetrievalResultEntry } from "../../retrieval/RetrievalResult";
 import { LLMDynamicHandle } from "../LLMDynamicHandle";
@@ -138,8 +138,6 @@ export class ProcessingController {
     /** @internal */
     private readonly connector: ProcessingConnector,
     /** @internal */
-    private readonly input: ChatMessage,
-    /** @internal */
     private readonly config: KVConfig,
     /**
      * When getting history, should the latest user input be included in the history?
@@ -265,59 +263,7 @@ export class ProcessingController {
   }
 
   public getPredictionConfig(): LLMPredictionConfig {
-    const config = globalConfigSchematics.parsePartial(this.config);
-    const result: LLMPredictionConfig = {};
-
-    const maxPredictedTokens = config.get("llm.prediction.maxPredictedTokens");
-    if (maxPredictedTokens !== undefined) {
-      result.maxPredictedTokens = maxPredictedTokens.checked ? maxPredictedTokens.value : false;
-    }
-    const temperature = config.get("llm.prediction.temperature");
-    if (temperature !== undefined) {
-      result.temperature = temperature;
-    }
-
-    const stopStrings = config.get("llm.prediction.stopStrings");
-    if (stopStrings !== undefined) {
-      result.stopStrings = stopStrings;
-    }
-
-    const contextOverflowPolicy = config.get("llm.prediction.contextOverflowPolicy");
-    if (contextOverflowPolicy !== undefined) {
-      result.contextOverflowPolicy = contextOverflowPolicy;
-    }
-
-    const structured = config.get("llm.prediction.structured");
-    if (structured !== undefined) {
-      result.structured = structured;
-    }
-
-    const topKSampling = config.get("llm.prediction.topKSampling");
-    if (topKSampling !== undefined) {
-      result.topKSampling = topKSampling;
-    }
-
-    const repeatPenalty = config.get("llm.prediction.repeatPenalty");
-    if (repeatPenalty !== undefined) {
-      result.repeatPenalty = repeatPenalty ? repeatPenalty.value : false;
-    }
-
-    const minPSampling = config.get("llm.prediction.minPSampling");
-    if (minPSampling !== undefined) {
-      result.minPSampling = minPSampling ? minPSampling.value : false;
-    }
-
-    const topPSampling = config.get("llm.prediction.topPSampling");
-    if (topPSampling !== undefined) {
-      result.topPSampling = topPSampling ? topPSampling.value : false;
-    }
-
-    const cpuThreads = config.get("llm.prediction.llama.cpuThreads");
-    if (cpuThreads !== undefined) {
-      result.cpuThreads = cpuThreads;
-    }
-
-    return result;
+    return kvConfigToLLMPredictionConfig(this.config);
   }
 
   /**

--- a/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
@@ -115,7 +115,6 @@ export function createLlmBackendInterface() {
         z.object({
           type: z.literal("generate"),
           taskId: z.string(),
-          input: chatMessageDataSchema,
           config: kvConfigSchema,
           /** Processing Context Identifier */
           pci: z.string(),

--- a/packages/lms-kv-config/src/KVConfig.ts
+++ b/packages/lms-kv-config/src/KVConfig.ts
@@ -417,6 +417,22 @@ export class KVConfigSchematics<
     return this.parseField(fieldSchema, fullKey, config.fields.find(f => f.key === fullKey)?.value);
   }
 
+  public accessPartial<TKey extends keyof TKVConfigSchema & string>(
+    config: KVConfig,
+    key: TKey,
+  ): TKVConfigSchema[TKey]["type"] | undefined {
+    const fullKey = this.baseKey + key;
+    const fieldSchema = this.fields.get(key);
+    if (fieldSchema === undefined) {
+      throw new Error(`Field with key ${fullKey} does not exist`);
+    }
+    return this.parseFieldWithoutDefault(
+      fieldSchema,
+      fullKey,
+      config.fields.find(f => f.key === fullKey)?.value,
+    );
+  }
+
   /**
    * Gets a slice of the config schema with the given key patterns. Support syntax:
    *

--- a/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
@@ -1,0 +1,58 @@
+import { type KVConfig, type LLMPredictionConfig } from "@lmstudio/lms-shared-types";
+import { globalConfigSchematics } from "../schema";
+
+export function kvConfigToLLMPredictionConfig(config: KVConfig) {
+  const result: LLMPredictionConfig = {};
+  const parsed = globalConfigSchematics.parsePartial(config);
+
+  const maxPredictedTokens = parsed.get("llm.prediction.maxPredictedTokens");
+  if (maxPredictedTokens !== undefined) {
+    result.maxPredictedTokens = maxPredictedTokens.checked ? maxPredictedTokens.value : false;
+  }
+  const temperature = parsed.get("llm.prediction.temperature");
+  if (temperature !== undefined) {
+    result.temperature = temperature;
+  }
+
+  const stopStrings = parsed.get("llm.prediction.stopStrings");
+  if (stopStrings !== undefined) {
+    result.stopStrings = stopStrings;
+  }
+
+  const contextOverflowPolicy = parsed.get("llm.prediction.contextOverflowPolicy");
+  if (contextOverflowPolicy !== undefined) {
+    result.contextOverflowPolicy = contextOverflowPolicy;
+  }
+
+  const structured = parsed.get("llm.prediction.structured");
+  if (structured !== undefined) {
+    result.structured = structured;
+  }
+
+  const topKSampling = parsed.get("llm.prediction.topKSampling");
+  if (topKSampling !== undefined) {
+    result.topKSampling = topKSampling;
+  }
+
+  const repeatPenalty = parsed.get("llm.prediction.repeatPenalty");
+  if (repeatPenalty !== undefined) {
+    result.repeatPenalty = repeatPenalty ? repeatPenalty.value : false;
+  }
+
+  const minPSampling = parsed.get("llm.prediction.minPSampling");
+  if (minPSampling !== undefined) {
+    result.minPSampling = minPSampling ? minPSampling.value : false;
+  }
+
+  const topPSampling = parsed.get("llm.prediction.topPSampling");
+  if (topPSampling !== undefined) {
+    result.topPSampling = topPSampling ? topPSampling.value : false;
+  }
+
+  const cpuThreads = parsed.get("llm.prediction.llama.cpuThreads");
+  if (cpuThreads !== undefined) {
+    result.cpuThreads = cpuThreads;
+  }
+
+  return result;
+}

--- a/packages/lms-kv-config/src/index.ts
+++ b/packages/lms-kv-config/src/index.ts
@@ -1,3 +1,4 @@
+export { kvConfigToLLMPredictionConfig } from "./conversion/llmPredictionConfig";
 export {
   KVConfigSchematics,
   KVFieldValueTypeLibrary,

--- a/publish/sdk/index.mjs
+++ b/publish/sdk/index.mjs
@@ -1,2 +1,2 @@
 import sdk from "./dist/index.js";
-export const { LMStudioClient } = sdk;
+export const { LMStudioClient, ChatHistory, ChatMessage, FileHandle, MaybeMutable } = sdk;


### PR DESCRIPTION
- Export the method to convert from KVConfig to LLMPredictionConfig.
- Export ChatHistory and other classes to mjs export.
- Added method to access a field in KVConfig without defaulting.