### PR TITLE
Add cpuThreadPoolSize to llm.load.llama config schematics

### DIFF
--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -184,7 +184,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
                 0,
               ]),
           )
-          .field("cpuThreadPools", "numeric", { min: 1, machineDependent: true }, 4)
+          .field("cpuThreadPoolSize", "numeric", { min: 1, machineDependent: true }, 4)
           .field("evalBatchSize", "numeric", { min: 1, int: true }, 512)
           .field(
             "flashAttention",

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -184,6 +184,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
                 0,
               ]),
           )
+          .field("cpuThreadPools", "numeric", { min: 1, machineDependent: true }, 4)
           .field("evalBatchSize", "numeric", { min: 1, int: true }, 512)
           .field(
             "flashAttention",


### PR DESCRIPTION
Allows the number of threads allocated in the llama.cpp engine threadpool at load time to be set as a config parameter

A part of the fix for:
- https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/130