### PR TITLE
Add documentation for LLMJinjaInputFormat

### DIFF
--- a/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
+++ b/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
@@ -39,7 +39,102 @@ export const llmManualPromptTemplateSchema = z.object({
 });
 
 /**
- * TODO: Documentation
+ * This type contains a unique literal for each known input format for Jinja template rendering.
+ * ChatHistoryData will be converted to this format before being passed to the Jinja template.
+ *
+ * See below for examples of each format.
+ *
+ * ### promptOnly
+ * Prompt in `content` field, no mention of images
+ * ```typescript
+ * { "messages": [{ role: "user", content: "What is this?" }] }
+ * ```
+ *
+ * ### promptWithImages
+ * Prompt in 'content' field, with 1-n images embedded at the start as `<image>` strings
+ * ```typescript
+ * { "messages": [{ role: "user", content: "<image>What is this?"}] }
+ * ```
+ *
+ * ### promptWithImagesNewline
+ * Prompt in 'content' field, with 1-n images embedded at the start as `<image>\n` strings
+ * ```typescript
+ * { "messages": [{ role: "user", content: "<image>\nWhat is this?"}] }
+ * ```
+ *
+ * ### promptWithNumberedImages1
+ * Prompt in 'content' field, with 1-n numbered images embedded at the start as `<image_*>` strings
+ * ```typescript
+ * { "messages": [{ role: "user", content: "<image_1><image_2>What is this?"}] }
+ * ```
+ *
+ * ### promptWithNumberedImages2
+ * Prompt in 'content' field, with 1-n numbered images embedded at the start as `[img-*]` strings
+ * ```typescript
+ * { "messages": [{ role: "user", content: "[img-1][img-2]What is this?"}] }
+ * ```
+ *
+ * ### messageListWithImageType1
+ * 'content' field contains a list of message parts, where each part is of type "image" or "text".
+ * "text" parts contain text in the `text` field.
+ * ```typescript
+ * {
+ *   "messages": [{
+ *     role: "user",
+ *     content: [{ type: "image" }{ type: "text", text: "What is this?"}]
+ *   }]
+ * }
+ * ```
+ *
+ * ### messageListWithImageType2
+ * 'content' field contains a list of message parts, where each part is of type "image" or "text".
+ * "text" parts contain text in the `content` field.
+ * ```typescript
+ * {
+ *   "messages": [{
+ *     role: "user",
+ *     content: [{ type: "image" }{ type: "text", content: "What is this?"}]
+ *   }]
+ * }
+ * ```
+ *
+ * ### llamaCustomTools
+ * Llama tool-use format. No images. The "assistant" can make requests to tool calls. The "tool" 
+ * role contains the results of the tool calls. The "custom_tools" field is used to define the tools
+ * that the model can request.
+ * ```typescript
+ * {
+ *   messages: [
+ *     { role: "user", content: "What's the delivery date for order 123" },
+ *     { role: "assistant", content: "Let me check your delivery date.",
+ *       tool_calls: [{
+ *         type: "function",
+ *         function: { name: "get_delivery_date", arguments: "{\"order_id\":\"123\"}" }
+ *       }]
+ *     },
+ *     { role: "tool", content: "The delivery date is March 1st, 2024" }
+ *   ],
+ *   custom_tools: [{
+ *     type: "function",
+ *     function: {
+ *       name: "get_delivery_date",
+ *       description: "Get the delivery date for a customer's order",
+ *       parameters: {
+ *         type: "object",
+ *         properties: {
+ *           order_id: {
+ *             type: "string",
+ *             description: "The customer's order ID."
+ *           }
+ *         },
+ *         required: ["order_id"],
+ *         additionalProperties: false
+ *       }
+ *     }
+ *   }]
+ * }
+ * ```
+ *
  * @public
  */
 export type LLMJinjaInputFormat =


### PR DESCRIPTION
Documents the previously ambiguous `LLMJinjaInputFormat`, providing examples of the exact format represented by each