### PR TITLE
Add mistralTools, qwenTools LLMJinjaInputFormats

### DIFF
--- a/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
+++ b/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
@@ -99,7 +99,7 @@ export const llmManualPromptTemplateSchema = z.object({
  * ```
  *
  * ### llamaCustomTools
- * Llama tool-use format. No images. The "assistant" can make requests to tool calls. The "tool" 
+ * Llama tool-use format. No images. The "assistant" can make requests to tool calls. The "tool"
  * role contains the results of the tool calls. The "custom_tools" field is used to define the tools
  * that the model can request.
  * ```typescript
@@ -112,7 +112,7 @@ export const llmManualPromptTemplateSchema = z.object({
  *         function: { name: "get_delivery_date", arguments: "{\"order_id\":\"123\"}" }
  *       }]
  *     },
- *     { role: "tool", content: "The delivery date is March 1st, 2024" }
+ *     { role: "tool", content: '{"order_id": "123", "delivery_date": "March 1st, 2024"}' }
  *   ],
  *   custom_tools: [{
  *     type: "function",
@@ -134,6 +134,42 @@ export const llmManualPromptTemplateSchema = z.object({
  *   }]
  * }
  * ```
+ * ### mistralTools
+ * Mistral tool-use format. Similar to llamaCustomTools but with additional validation rules, and
+ * tools are passed through the "tools" field instead of the "custom_tools" field.
+ * IDs must be present in both "tool_calls" from "assistant" and in "tool_call_id" when a message
+ * is sent from the "tool" role. IDs must be 9 alphanumeric characters long.
+ * ```typescript
+ * {
+ *   messages: [
+ *     { role: "user", content: "What's the delivery date for order 123?" },
+ *     { role: "assistant", tool_calls: [{
+ *         id: "123456789",
+ *         function: {
+ *           name: "get_delivery_date",
+ *           arguments: "{\"order_id\":\"123\"}"
+ *         }
+ *     }]},
+ *     { role: "tool",
+ *       tool_call_id: "123456789",
+ *       content: '{"order_id": "123", "delivery_date": "March 1st, 2024"}'
+ *     }
+ *   ],
+ *   tools: [{
+ *     function: {
+ *       name: "get_delivery_date",
+ *       description: "Get the delivery date for a customer's order",
+ *       parameters: {
+ *         type: "object",
+ *         properties: {
+ *           order_id: { type: "string", description: "The customer's order ID." }
+ *         },
+ *         required: ["order_id"]
+ *       }
+ *     }
+ *   }]
+ * }
+ * ```
  *
  * @public
  */
@@ -145,7 +181,8 @@ export type LLMJinjaInputFormat =
   | "promptWithNumberedImages2"
   | "messageListWithImageType1"
   | "messageListWithImageType2"
-  | "llamaCustomTools";
+  | "llamaCustomTools"
+  | "mistralTools";
 export const llmJinjaInputFormatSchema = z.enum([
   "promptOnly",
   "promptWithImages",
@@ -155,6 +192,7 @@ export const llmJinjaInputFormatSchema = z.enum([
   "messageListWithImageType1",
   "messageListWithImageType2",
   "llamaCustomTools",
+  "mistralTools",
 ]);
 
 /**

--- a/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
+++ b/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
@@ -134,6 +134,7 @@ export const llmManualPromptTemplateSchema = z.object({
  *   }]
  * }
  * ```
+ *
  * ### mistralTools
  * Mistral tool-use format. Similar to llamaCustomTools but with additional validation rules, and
  * tools are passed through the "tools" field instead of the "custom_tools" field.
@@ -155,19 +156,26 @@ export const llmManualPromptTemplateSchema = z.object({
  *       content: '{"order_id": "123", "delivery_date": "March 1st, 2024"}'
  *     }
  *   ],
- *   tools: [{
- *     function: {
- *       name: "get_delivery_date",
- *       description: "Get the delivery date for a customer's order",
- *       parameters: {
- *         type: "object",
- *         properties: {
- *           order_id: { type: "string", description: "The customer's order ID." }
- *         },
- *         required: ["order_id"]
- *       }
- *     }
- *   }]
+ *   tools: [<tool jsons here>]
+ * }
+ * ```
+ *
+ * ### qwenTools
+ * The same as `llamaCustomTools`, but the "tools" field is used to define the tools
+ * that the model can request (instead of "customTools" for `llamaCustomTools`).
+ * ```typescript
+ * {
+ *   messages: [
+ *     { role: "user", content: "What's the delivery date for order 123" },
+ *     { role: "assistant", content: "Let me check your delivery date.",
+ *       tool_calls: [{
+ *         type: "function",
+ *         function: { name: "get_delivery_date", arguments: "{\"order_id\":\"123\"}" }
+ *       }]
+ *     },
+ *     { role: "tool", content: '{"order_id": "123", "delivery_date": "March 1st, 2024"}' }
+ *   ],
+ *   tools: [<tool jsons here>]
  * }
  * ```
  *

--- a/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
+++ b/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
@@ -182,7 +182,8 @@ export type LLMJinjaInputFormat =
   | "messageListWithImageType1"
   | "messageListWithImageType2"
   | "llamaCustomTools"
-  | "mistralTools";
+  | "mistralTools"
+  | "qwenTools";
 export const llmJinjaInputFormatSchema = z.enum([
   "promptOnly",
   "promptWithImages",
@@ -193,6 +194,7 @@ export const llmJinjaInputFormatSchema = z.enum([
   "messageListWithImageType2",
   "llamaCustomTools",
   "mistralTools",
+  "qwenTools",
 ]);
 
 /**

--- a/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
+++ b/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
@@ -162,7 +162,7 @@ export const llmManualPromptTemplateSchema = z.object({
  *
  * ### qwenTools
  * The same as `llamaCustomTools`, but the "tools" field is used to define the tools
- * that the model can request (instead of "customTools" for `llamaCustomTools`).
+ * that the model can request (instead of "custom_tools" for `llamaCustomTools`).
  * ```typescript
  * {
  *   messages: [


### PR DESCRIPTION
Supercedes https://github.com/lmstudio-ai/lmstudio.js/pull/112

Adds the required `LLMJinjaInputFormat` for Mistral tool-enabled models like https://huggingface.co/bartowski/Ministral-8B-Instruct-2410-GGUF amd https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407. Called `mistralTools`.

Also adds the required `LLMJinjaInputFormat` for Qwen tool-enabled models like https://huggingface.co/lmstudio-community/Qwen2.5-7B-Instruct-GGUF. Called `qwenTools`.

Also adds documentation and cleans up a bit of documentation for `llamaCustomTools`.