### PR TITLE
[LLMTool] Make function description optional

### DIFF
--- a/packages/lms-shared-types/src/llm/LLMToolUseSetting.ts
+++ b/packages/lms-shared-types/src/llm/LLMToolUseSetting.ts
@@ -33,7 +33,7 @@ export type LLMTool = {
   type: "function";
   function: {
     name: string;
-    description: string;
+    description?: string;
     parameters?: LLMToolParameters;
   };
   // add more tool types here
@@ -45,7 +45,7 @@ export const llmToolSchema = z.discriminatedUnion("type", [
     type: z.literal("function"),
     function: z.object({
       name: z.string(),
-      description: z.string(),
+      description: z.string().optional(),
       parameters: llmToolParametersSchema.optional(),
     }),
   }),


### PR DESCRIPTION
Makes the description field of a function in `tools` optional, matching OpenAI's API

![Screenshot 2024-12-03 at 9 57 56 AM](https://github.com/user-attachments/assets/ba71512d-f90b-4316-b99c-33247e332578)
