### PR TITLE
Mark more integer API schema fields as integers

### DIFF
--- a/packages/lms-client/src/retrieval/RetrievalOpts.ts
+++ b/packages/lms-client/src/retrieval/RetrievalOpts.ts
@@ -138,7 +138,7 @@ export type RetrievalOpts = RetrievalCallbacks & {
 };
 export const retrievalOptsSchema = z.object({
   chunkingMethod: retrievalChunkingMethodSchema.optional(),
-  limit: z.number().optional(),
+  limit: z.number().int().optional(),
   embeddingModel: z.instanceof(EmbeddingDynamicHandle).optional(),
   databasePath: z.string().optional(),
   signal: z.instanceof(AbortSignal).optional(),

--- a/packages/lms-communication/src/Transport.ts
+++ b/packages/lms-communication/src/Transport.ts
@@ -17,26 +17,26 @@ const clientToServerMessageSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("channelCreate"),
     endpoint: z.string(),
-    channelId: z.number(),
+    channelId: z.number().int(),
     creationParameter: serializedOpaqueSchema,
   }),
   z.object({
     type: z.literal("channelSend"),
-    channelId: z.number(),
+    channelId: z.number().int(),
     message: serializedOpaqueSchema,
-    ackId: z.number().optional(),
+    ackId: z.number().int().optional(),
   }),
   z.object({
     type: z.literal("channelAck"),
-    channelId: z.number(),
-    ackId: z.number(),
+    channelId: z.number().int(),
+    ackId: z.number().int(),
   }),
 
   // RPC
   z.object({
     type: z.literal("rpcCall"),
     endpoint: z.string(),
-    callId: z.number(),
+    callId: z.number().int(),
     parameter: serializedOpaqueSchema,
   }),
 
@@ -45,11 +45,11 @@ const clientToServerMessageSchema = z.discriminatedUnion("type", [
     type: z.literal("signalSubscribe"),
     creationParameter: serializedOpaqueSchema,
     endpoint: z.string(),
-    subscribeId: z.number(),
+    subscribeId: z.number().int(),
   }),
   z.object({
     type: z.literal("signalUnsubscribe"),
-    subscribeId: z.number(),
+    subscribeId: z.number().int(),
   }),
 
   // Writable signal
@@ -57,15 +57,15 @@ const clientToServerMessageSchema = z.discriminatedUnion("type", [
     type: z.literal("writableSignalSubscribe"),
     creationParameter: serializedOpaqueSchema,
     endpoint: z.string(),
-    subscribeId: z.number(),
+    subscribeId: z.number().int(),
   }),
   z.object({
     type: z.literal("writableSignalUnsubscribe"),
-    subscribeId: z.number(),
+    subscribeId: z.number().int(),
   }),
   z.object({
     type: z.literal("writableSignalUpdate"),
-    subscribeId: z.number(),
+    subscribeId: z.number().int(),
     patches: z.array(serializedOpaqueSchema),
     tags: z.array(z.string()),
   }),
@@ -86,60 +86,60 @@ const serverToClientMessageSchema = z.discriminatedUnion("type", [
   // Channel
   z.object({
     type: z.literal("channelSend"),
-    channelId: z.number(),
+    channelId: z.number().int(),
     message: serializedOpaqueSchema,
-    ackId: z.number().optional(),
+    ackId: z.number().int().optional(),
   }),
   z.object({
     type: z.literal("channelAck"),
-    channelId: z.number(),
-    ackId: z.number(),
+    channelId: z.number().int(),
+    ackId: z.number().int(),
   }),
   z.object({
     type: z.literal("channelClose"),
-    channelId: z.number(),
+    channelId: z.number().int(),
   }),
   z.object({
     type: z.literal("channelError"),
-    channelId: z.number(),
+    channelId: z.number().int(),
     error: serializedLMSExtendedErrorSchema,
   }),
 
   // RPC
   z.object({
     type: z.literal("rpcResult"),
-    callId: z.number(),
+    callId: z.number().int(),
     result: serializedOpaqueSchema,
   }),
   z.object({
     type: z.literal("rpcError"),
-    callId: z.number(),
+    callId: z.number().int(),
     error: serializedLMSExtendedErrorSchema,
   }),
 
   // Readonly signal
   z.object({
     type: z.literal("signalUpdate"),
-    subscribeId: z.number(),
+    subscribeId: z.number().int(),
     patches: z.array(serializedOpaqueSchema),
     tags: z.array(z.string()),
   }),
   z.object({
     type: z.literal("signalError"),
-    subscribeId: z.number(),
+    subscribeId: z.number().int(),
     error: serializedLMSExtendedErrorSchema,
   }),
 
   // Writable signal
   z.object({
     type: z.literal("writableSignalUpdate"),
-    subscribeId: z.number(),
+    subscribeId: z.number().int(),
     patches: z.array(serializedOpaqueSchema),
     tags: z.array(z.string()),
   }),
   z.object({
     type: z.literal("writableSignalError"),
-    subscribeId: z.number(),
+    subscribeId: z.number().int(),
     error: serializedLMSExtendedErrorSchema,
   }),
 ]);

--- a/packages/lms-external-backend-interfaces/src/filesBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/filesBackendInterface.ts
@@ -21,7 +21,7 @@ export function createFilesBackendInterface() {
       returns: z.object({
         identifier: z.string(),
         fileType: fileTypeSchema,
-        sizeBytes: z.number(),
+        sizeBytes: z.number().int(),
       }),
     });
 }

--- a/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
@@ -73,7 +73,7 @@ export function createLlmBackendInterface() {
         inputString: z.string(),
       }),
       returns: z.object({
-        tokenCount: z.number(),
+        tokenCount: z.number().int(),
       }),
     });
 }

--- a/packages/lms-external-backend-interfaces/src/repositoryBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/repositoryBackendInterface.ts
@@ -55,7 +55,7 @@ export function createRepositoryBackendInterface() {
       creationParameter: z.object({
         artifactOwner: kebabCaseSchema,
         artifactName: kebabCaseSchema,
-        revisionNumber: z.number().nullable(),
+        revisionNumber: z.number().int().nullable(),
         path: z.string(),
       }),
       toClientPacket: z.discriminatedUnion("type", [

--- a/packages/lms-external-backend-interfaces/src/retrievalBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/retrievalBackendInterface.ts
@@ -22,30 +22,30 @@ export function createRetrievalBackendInterface() {
     toClientPacket: z.discriminatedUnion("type", [
       z.object({
         type: z.literal("onFileProcessList"),
-        indices: z.array(z.number()),
+        indices: z.array(z.number().int()),
       }),
       z.object({
         type: z.literal("onFileProcessingStart"),
-        index: z.number(),
+        index: z.number().int(),
       }),
       z.object({
         type: z.literal("onFileProcessingEnd"),
-        index: z.number(),
+        index: z.number().int(),
       }),
       z.object({
         type: z.literal("onFileProcessingStepStart"),
-        index: z.number(),
+        index: z.number().int(),
         step: retrievalFileProcessingStepSchema,
       }),
       z.object({
         type: z.literal("onFileProcessingStepProgress"),
-        index: z.number(),
+        index: z.number().int(),
         step: retrievalFileProcessingStepSchema,
         progress: z.number(),
       }),
       z.object({
         type: z.literal("onFileProcessingStepEnd"),
-        index: z.number(),
+        index: z.number().int(),
         step: retrievalFileProcessingStepSchema,
       }),
       z.object({

--- a/packages/lms-shared-types/src/ChatHistoryData.ts
+++ b/packages/lms-shared-types/src/ChatHistoryData.ts
@@ -40,7 +40,7 @@ export const chatMessagePartFileDataSchema = z.object({
   type: z.literal("file"),
   name: z.string(),
   identifier: z.string(),
-  sizeBytes: z.number(),
+  sizeBytes: z.number().int(),
   fileType: fileTypeSchema,
 });
 

--- a/packages/lms-shared-types/src/CitationSource.ts
+++ b/packages/lms-shared-types/src/CitationSource.ts
@@ -14,6 +14,6 @@ export interface CitationSource {
 export const citationSourceSchema = z.object({
   fileName: z.string(),
   absoluteFilePath: z.string().optional(),
-  pageNumber: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
-  lineNumber: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
+  pageNumber: z.union([z.number().int(), z.tuple([z.number().int(), z.number().int()])]).optional(),
+  lineNumber: z.union([z.number().int(), z.tuple([z.number().int(), z.number().int()])]).optional(),
 }) as z.Schema<CitationSource>;

--- a/packages/lms-shared-types/src/DownloadedModel.ts
+++ b/packages/lms-shared-types/src/DownloadedModel.ts
@@ -27,13 +27,13 @@ export const downloadedModelSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("llm"),
     path: z.string(),
-    sizeBytes: z.number(),
+    sizeBytes: z.number().int(),
     architecture: z.string().optional(),
   }),
   z.object({
     type: z.literal("embedding"),
     path: z.string(),
-    sizeBytes: z.number(),
+    sizeBytes: z.number().int(),
     architecture: z.string().optional(),
   }),
 ]);

--- a/packages/lms-shared-types/src/GenericErrorDisplayData.ts
+++ b/packages/lms-shared-types/src/GenericErrorDisplayData.ts
@@ -10,19 +10,19 @@ export const genericErrorDisplayDataSchema = [
     code: z.literal("generic.noModelMatchingQuery"),
     query: modelQuerySchema,
     loadedModelsSample: z.array(z.string()),
-    totalLoadedModels: z.number(),
+    totalLoadedModels: z.number().int(),
   }),
   z.object({
     code: z.literal("generic.pathNotFound"),
     path: z.string(),
     availablePathsSample: z.array(z.string()),
-    totalModels: z.number(),
+    totalModels: z.number().int(),
   }),
   z.object({
     code: z.literal("generic.identifierNotFound"),
     identifier: z.string(),
     loadedModelsSample: z.array(z.string()),
-    totalLoadedModels: z.number(),
+    totalLoadedModels: z.number().int(),
   }),
   z.object({
     code: z.literal("generic.domainMismatch"),

--- a/packages/lms-shared-types/src/PluginManifest.ts
+++ b/packages/lms-shared-types/src/PluginManifest.ts
@@ -26,5 +26,5 @@ export const pluginManifestSchema = z.object({
   owner: kebabCaseSchema,
   name: kebabCaseSchema,
   description: z.string(),
-  revision: z.number().optional(),
+  revision: z.number().int().optional(),
 });

--- a/packages/lms-shared-types/src/Runtime.ts
+++ b/packages/lms-shared-types/src/Runtime.ts
@@ -11,8 +11,8 @@ export interface Accelerator {
 }
 export const acceleratorSchema = z.object({
   name: z.string(),
-  deviceId: z.number(),
-  totalMemoryBytes: z.number(),
+  deviceId: z.number().int(),
+  totalMemoryBytes: z.number().int(),
   type: acceleratorTypeSchema,
 });
 

--- a/packages/lms-shared-types/src/llm/LLMPredictionStats.ts
+++ b/packages/lms-shared-types/src/llm/LLMPredictionStats.ts
@@ -46,9 +46,9 @@ export const llmPredictionStatsSchema = z.object({
   tokensPerSecond: z.number().optional(),
   numGpuLayers: z.number().optional(),
   timeToFirstTokenSec: z.number().optional(),
-  promptTokensCount: z.number().optional(),
-  predictedTokensCount: z.number().optional(),
-  totalTokensCount: z.number().optional(),
+  promptTokensCount: z.number().int().optional(),
+  predictedTokensCount: z.number().int().optional(),
+  totalTokensCount: z.number().int().optional(),
 });
 /** @public */
 export interface LLMPredictionStats {

--- a/packages/lms-shared-types/src/llm/processing/ProcessingUpdate.ts
+++ b/packages/lms-shared-types/src/llm/processing/ProcessingUpdate.ts
@@ -60,7 +60,7 @@ export const processingUpdateStatusCreateSchema = z.object({
   id: z.string(),
   state: statusStepStateSchema,
   location: blockLocationSchema.optional(),
-  indentation: z.number().optional(),
+  indentation: z.number().int().optional(),
 });
 
 export type ProcessingUpdateStatusUpdate = {
@@ -98,8 +98,8 @@ export const processingUpdateCitationBlockCreateSchema = z.object({
   citedText: z.string(),
   fileName: z.string(),
   fileIdentifier: z.string(),
-  pageNumber: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
-  lineNumber: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
+  pageNumber: z.union([z.number().int(), z.tuple([z.number().int(), z.number().int()])]).optional(),
+  lineNumber: z.union([z.number().int(), z.tuple([z.number().int(), z.number().int()])]).optional(),
 });
 
 // Debug Info Block

--- a/packages/lms-shared-types/src/repository/DownloadProgressUpdate.ts
+++ b/packages/lms-shared-types/src/repository/DownloadProgressUpdate.ts
@@ -9,7 +9,7 @@ export interface DownloadProgressUpdate {
   speedBytesPerSecond: number;
 }
 export const downloadProgressUpdateSchema = z.object({
-  downloadedBytes: z.number(),
-  totalBytes: z.number(),
+  downloadedBytes: z.number().int(),
+  totalBytes: z.number().int(),
   speedBytesPerSecond: z.number(),
 }) as ZodSchema<DownloadProgressUpdate>;

--- a/packages/lms-shared-types/src/retrieval/InternalRetrievalResult.ts
+++ b/packages/lms-shared-types/src/retrieval/InternalRetrievalResult.ts
@@ -10,9 +10,9 @@ export interface InternalRetrievalResultEntry {
 export const internalRetrievalResultEntrySchema = z.object({
   content: z.string(),
   score: z.number(),
-  sourceIndex: z.number(),
-  pageNumber: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
-  lineNumber: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
+  sourceIndex: z.number().int(),
+  pageNumber: z.union([z.number().int(), z.tuple([z.number().int(), z.number().int()])]).optional(),
+  lineNumber: z.union([z.number().int(), z.tuple([z.number().int(), z.number().int()])]).optional(),
 });
 
 /**

--- a/packages/lms-shared-types/src/retrieval/RetrievalChunkingMethod.ts
+++ b/packages/lms-shared-types/src/retrieval/RetrievalChunkingMethod.ts
@@ -11,8 +11,8 @@ export type RetrievalChunkingMethod = {
 export const retrievalChunkingMethodSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("recursive-v1"),
-    chunkSize: z.number(),
-    chunkOverlap: z.number(),
+    chunkSize: z.number().int(),
+    chunkOverlap: z.number().int(),
   }),
 ]);
 


### PR DESCRIPTION
PR is based on reviewing all the `z.number()` schema entries and looking for those which are not already marked as integers and are one of the following:

* operation or entity IDs
* byte/token/model counts
* array indices
* revision numbers
* page or line numbers
* indentation level counts
