### PR TITLE
[LLMJinjaPromptTemplate] templateHasTools -> useTools, make inputConfig required

### DIFF
--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -22,6 +22,7 @@ import {
   llmApplyPromptTemplateOptsSchema,
   type LLMCompletionContextInput,
   llmCompletionContextInputSchema,
+  type LLMJinjaInputConfig,
   type LLMPredictionConfig,
   llmPredictionConfigSchema,
   type LLMPredictionFragment,
@@ -75,6 +76,14 @@ function splitOpts(opts: LLMPredictionOpts): [LLMPredictionConfig, LLMPrediction
 const noFormattingTemplate = text`
   {% for message in messages %}{{ message['content'] }}{% endfor %}
 `;
+const noFormattingInputConfig: LLMJinjaInputConfig = {
+  messagesConfig: {
+    contentConfig: {
+      type: "string",
+    },
+  },
+  useTools: false,
+};
 
 /**
  * This represents a set of requirements for a model. It is not tied to a specific model, but rather
@@ -265,6 +274,7 @@ export class LLMDynamicHandle extends DynamicHandle<// prettier-ignore
                   bosToken: "",
                   eosToken: "",
                   template: noFormattingTemplate,
+                  inputConfig: noFormattingInputConfig,
                 },
                 stopStrings: [],
               },

--- a/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
+++ b/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
@@ -132,11 +132,11 @@ export const llmJinjaInputMessagesConfigSchema = z.object({
  */
 export interface LLMJinjaInputConfig {
   messagesConfig: LLMJinjaInputMessagesConfig;
-  templateHasTools: boolean;
+  useTools: boolean;
 }
 export const llmJinjaInputConfigSchema = z.object({
   messagesConfig: llmJinjaInputMessagesConfigSchema,
-  templateHasTools: z.boolean(),
+  useTools: z.boolean(),
 });
 
 /**
@@ -155,13 +155,13 @@ export interface LLMJinjaPromptTemplate {
   /**
    * Config for how ChatHistoryData should be input to jinja for prompt rendering.
    */
-  inputConfig?: LLMJinjaInputConfig;
+  inputConfig: LLMJinjaInputConfig;
 }
 export const llmJinjaPromptTemplateSchema = z.object({
   template: z.string(),
   bosToken: z.string(),
   eosToken: z.string(),
-  inputConfig: llmJinjaInputConfigSchema.optional(),
+  inputConfig: llmJinjaInputConfigSchema,
 });
 
 /** @public */


### PR DESCRIPTION
`inputConfig` becomes required, since it is needed to go from `ChatHistoryData` -> input to the jinja render function