### PR TITLE
Allow KVConfigSchematics to union across schematics that are scoped at different levels.

### DIFF
--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -373,7 +373,7 @@ type ValueTypeMap =
 /**
  * Any config schematics that uses the value types defined in the type library.
  */
-export type TypedConfigSchematics = KVConfigSchematics<ValueTypeMap, any, any>;
+export type TypedConfigSchematics = KVConfigSchematics<ValueTypeMap, any>;
 
 export type GlobalKVValueTypeMap = InferValueTypeMap<typeof kvValueTypesLibrary>;
 /**

--- a/packages/lms-shared-types/src/SerializedKVConfigSchematics.ts
+++ b/packages/lms-shared-types/src/SerializedKVConfigSchematics.ts
@@ -6,13 +6,15 @@ import { jsonSerializableSchema } from "./JSONSerializable.js";
  * @public
  */
 export interface SerializedKVConfigSchematicsField {
-  key: string;
+  shortKey: string;
+  fullKey: string;
   typeKey: string;
   typeParams: any;
   defaultValue: any;
 }
 export const serializedKVConfigSchematicsFieldSchema = z.object({
-  key: z.string(),
+  shortKey: z.string(),
+  fullKey: z.string(),
   typeKey: z.string(),
   typeParams: jsonSerializableSchema,
   defaultValue: jsonSerializableSchema,
@@ -22,11 +24,9 @@ export const serializedKVConfigSchematicsFieldSchema = z.object({
  * @public
  */
 export interface SerializedKVConfigSchematics {
-  baseKey: string;
   fields: Array<SerializedKVConfigSchematicsField>;
 }
 export const serializedKVConfigSchematicsSchema = z.object({
-  baseKey: z.string(),
   fields: z.array(serializedKVConfigSchematicsFieldSchema),
 }) as z.ZodSchema<SerializedKVConfigSchematics>;
 


### PR DESCRIPTION
Before, `KVConfigSchematics` are just implemented as a `baseKey` + a list of allowed keys. For example, a `KVConfigSchematics` can have `baseKey = llm.prediction`, and have allowed keys being `temperature`. Thus accessing `temperature` will result in accessing `llm.prediction.temperature`.

However, this prevents us from unioning two `KVConfigSchematics` that have different base keys (meaning scoped at different levels).

This PR changes the approach into having an aliasing map. For the previous case, we will alias `temperature` to `llm.prediction.temperature`. This greatly increases the versatility of the `KVConfigSchematics`. For example, a `llmPrediction` schematics can include fields from the root level. We can even create alias. Reality can be whatever we want.

This _hopefully_ shouldn't change the public interface of `KVConfigSchematics` despite large changes.