### PR TITLE
[LLMLlamaAccelerationSetting] Add splitMode param

### DIFF
--- a/packages/lms-client/src/embedding/EmbeddingNamespace.ts
+++ b/packages/lms-client/src/embedding/EmbeddingNamespace.ts
@@ -33,6 +33,7 @@ export class EmbeddingNamespace extends ModelNamespace<
       "llama.acceleration.offloadRatio": config.gpuOffload?.ratio,
       "llama.load.mainGpu": config.gpuOffload?.mainGpu,
       "llama.load.tensorSplit": config.gpuOffload?.tensorSplit,
+      "llama.load.splitMode": config.gpuOffload?.splitMode,
       "contextLength": config.contextLength,
       "llama.ropeFrequencyBase": numberToCheckboxNumeric(config.ropeFrequencyBase, 0, 0),
       "llama.ropeFrequencyScale": numberToCheckboxNumeric(config.ropeFrequencyScale, 0, 0),

--- a/packages/lms-client/src/llm/LLMNamespace.ts
+++ b/packages/lms-client/src/llm/LLMNamespace.ts
@@ -35,6 +35,7 @@ export class LLMNamespace extends ModelNamespace<
       "llama.acceleration.offloadRatio": config.gpuOffload?.ratio,
       "llama.load.mainGpu": config.gpuOffload?.mainGpu,
       "llama.load.tensorSplit": config.gpuOffload?.tensorSplit,
+      "llama.load.splitMode": config.gpuOffload?.splitMode,
       "llama.flashAttention": config.flashAttention,
       "llama.ropeFrequencyBase": numberToCheckboxNumeric(config.ropeFrequencyBase, 0, 0),
       "llama.ropeFrequencyScale": numberToCheckboxNumeric(config.ropeFrequencyScale, 0, 0),

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -207,7 +207,8 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
   .scope("llama.load", builder =>
     builder
       .field("mainGpu", "llamaAccelerationMainGpu", { machineDependent: true }, 0)
-      .field("tensorSplit", "llamaAccelerationTensorSplit", { machineDependent: true }, [0]),
+      .field("tensorSplit", "llamaAccelerationTensorSplit", { machineDependent: true }, [0])
+      .field("splitMode", "splitMode", {}, "layer"),
   )
   .scope("embedding.load", builder =>
     builder

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -208,7 +208,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
     builder
       .field("mainGpu", "llamaAccelerationMainGpu", { machineDependent: true }, 0)
       .field("tensorSplit", "llamaAccelerationTensorSplit", { machineDependent: true }, [0])
-      .field("splitMode", "splitMode", {}, "layer"),
+      .field("splitMode", "llamaAccelerationSplitMode", {}, "layer"),
   )
   .scope("embedding.load", builder =>
     builder

--- a/packages/lms-kv-config/src/valueTypes.ts
+++ b/packages/lms-kv-config/src/valueTypes.ts
@@ -6,6 +6,7 @@ import {
   llmLlamaLogitBiasConfigSchema,
   llmLlamaMirostatSamplingConfigSchema,
   llmPromptTemplateSchema,
+  llmSplitModeSchema,
   llmStructuredPredictionSettingSchema,
   llmToolUseSettingSchema,
   modelDomainTypeSchema,
@@ -310,6 +311,25 @@ export const kvValueTypesLibrary = new KVFieldValueTypesLibraryBuilder({
           return t("config:customInputs.contextOverflowPolicy.truncateMiddle", "Truncate Middle");
         case "rollingWindow":
           return t("config:customInputs.contextOverflowPolicy.rollingWindow", "Rolling Window");
+      }
+    },
+  })
+  .valueType("splitMode", {
+    paramType: {},
+    schemaMaker: () => {
+      return llmSplitModeSchema;
+    },
+    effectiveEquals: (a, b) => {
+      return a === b;
+    },
+    stringify: (value, _typeParam, { t }) => {
+      switch (value) {
+        case "singleGpu":
+          return t("config:customInputs.splitMode.singleGpu", "Single GPU");
+        case "layer":
+          return t("config:customInputs.splitMode.layer", "Layer");
+        case "row":
+          return t("config:customInputs.splitMode.row", "Row");
       }
     },
   })

--- a/packages/lms-kv-config/src/valueTypes.ts
+++ b/packages/lms-kv-config/src/valueTypes.ts
@@ -314,25 +314,6 @@ export const kvValueTypesLibrary = new KVFieldValueTypesLibraryBuilder({
       }
     },
   })
-  .valueType("splitMode", {
-    paramType: {},
-    schemaMaker: () => {
-      return llmSplitModeSchema;
-    },
-    effectiveEquals: (a, b) => {
-      return a === b;
-    },
-    stringify: (value, _typeParam, { t }) => {
-      switch (value) {
-        case "singleGpu":
-          return t("config:customInputs.splitMode.singleGpu", "Single GPU");
-        case "layer":
-          return t("config:customInputs.splitMode.layer", "Layer");
-        case "row":
-          return t("config:customInputs.splitMode.row", "Row");
-      }
-    },
-  })
   .valueType("context", {
     paramType: {},
     schemaMaker: () => {
@@ -540,6 +521,25 @@ export const kvValueTypesLibrary = new KVFieldValueTypesLibraryBuilder({
     },
     stringify: value => {
       return value.join(", "); // TODO: Better display
+    },
+  })
+  .valueType("llamaAccelerationSplitMode", {
+    paramType: {},
+    schemaMaker: () => {
+      return llmSplitModeSchema;
+    },
+    effectiveEquals: (a, b) => {
+      return a === b;
+    },
+    stringify: (value, _typeParam, { t }) => {
+      switch (value) {
+        case "singleGpu":
+          return t("config:customInputs.llamaAccelerationSplitMode.singleGpu", "Single GPU");
+        case "layer":
+          return t("config:customInputs.llamaAccelerationSplitMode.layer", "Layer");
+        case "row":
+          return t("config:customInputs.llamaAccelerationSplitMode.row", "Row");
+      }
     },
   })
   .valueType("llamaMirostatSampling", {

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -119,6 +119,8 @@ export {
   llmLlamaAccelerationSettingSchema,
   LLMLoadModelConfig,
   llmLoadModelConfigSchema,
+  LLMSplitMode,
+  llmSplitModeSchema,
 } from "./llm/LLMLoadModelConfig.js";
 export {
   LLMContextOverflowPolicy,

--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -15,6 +15,17 @@ export const llmLlamaAccelerationOffloadRatioSchema = z.union([
 ]);
 
 /**
+ * How to split the model across GPUs.
+ * - "singleGpu": The model is run on a single GPU.
+ * - "layer": Splits layers and KV across GPUs.
+ * - "row": Splits layers and KV across GPUs, use tensor parallelism if supported
+ *
+ * @public
+ */
+export type LLMSplitMode = "singleGpu" | "layer" | "row";
+export const llmSplitModeSchema = z.enum(["singleGpu", "layer", "row"]);
+
+/**
  * Settings related to offloading work to the GPU.
  *
  * @public
@@ -23,11 +34,13 @@ export type LLMLlamaAccelerationSetting = {
   ratio: LLMLlamaAccelerationOffloadRatio;
   mainGpu: number;
   tensorSplit: Array<number>;
+  splitMode: LLMSplitMode;
 };
 export const llmLlamaAccelerationSettingSchema = z.object({
   ratio: llmLlamaAccelerationOffloadRatioSchema,
   mainGpu: z.number().int(),
   tensorSplit: z.array(z.number().int()),
+  splitMode: llmSplitModeSchema,
 });
 
 /** @public */

--- a/publish/sdk/src/exportedTypes.ts
+++ b/publish/sdk/src/exportedTypes.ts
@@ -105,6 +105,7 @@ export type {
   LLMPredictionStopReason,
   LLMPromptTemplate,
   LLMPromptTemplateType,
+  LLMSplitMode,
   LLMStructuredPredictionSetting,
   LLMTool,
   LLMToolParameters,


### PR DESCRIPTION
Adds the splitMode parameter to `LLMLlamaAccelerationSetting`.

Follows: https://github.com/ggerganov/llama.cpp/blob/f11cfdfd7fe29436fce512d934c2ff6b94bd89d2/include/llama.h#L210