### PR TITLE
Only show warning for V cache quantization

### DIFF
--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -211,7 +211,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
           .field(
             "vCacheQuantizationType",
             "llamaCacheQuantizationType",
-            { isExperimental: true, warning: "config:kvCacheQuantizationWarning" },
+            { isExperimental: true, warning: "config:llamaKvCacheQuantizationWarning" },
             "f16",
           ),
       ),

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -205,7 +205,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
           .field(
             "kCacheQuantizationType",
             "llamaCacheQuantizationType",
-            { isExperimental: true, warning: "config:kvCacheQuantizationWarning" },
+            { isExperimental: true },
             "f16",
           )
           .field(


### PR DESCRIPTION
Warning is still shown here https://github.com/lmstudio-ai/lmstudio.js/blob/076b9355a1d1d0958528acf3108ffd6a39350e48/packages/lms-kv-config/src/schema.ts#L214 for V cache quantization