### PR TITLE
Speculative Decoding changes

### DIFF
--- a/packages/lms-kv-config/src/KVConfig.ts
+++ b/packages/lms-kv-config/src/KVConfig.ts
@@ -778,6 +778,11 @@ export class KVConfigSchematics<
     return field.valueTypeParams;
   }
 
+  public hasFullKey(key: string): boolean {
+    const field = this.getFullKeyMap().get(key);
+    return field !== undefined;
+  }
+
   /**
    * Given a KVConfig, filter it to only include fields that are in the schematics.
    */

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -48,32 +48,12 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
       .field("stopStrings", "stringArray", {}, [])
       .field("toolCallStopStrings", "stringArray", {}, [])
       .field("structured", "llamaStructuredOutput", {}, { type: "none" })
-      .field("speculativeDecoding.enabled", "speculativeDecodingEnabled", {}, true)
-      .field(
-        "speculativeDecoding.draftModel",
-        "speculativeDecodingDraftModel",
-        {
-          dependencies: [
-            {
-              key: "llm.prediction.speculativeDecoding.enabled",
-              condition: { type: "equals", value: true },
-            },
-          ],
-        },
-        "",
-      )
       .field(
         "speculativeDecoding.numberOfDraftTokens",
         "numeric",
         {
           min: 1,
           int: true,
-          dependencies: [
-            {
-              key: "llm.prediction.speculativeDecoding.enabled",
-              condition: { type: "equals", value: true },
-            },
-          ],
         },
         1000,
       )
@@ -198,6 +178,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
         { int: true, min: -1, uncheckedHint: "config:seedUncheckedHint" },
         { checked: false, value: -1 },
       )
+      .field("speculativeDecoding.draftModel", "speculativeDecodingDraftModel", {}, "")
       .scope("llama", builder =>
         builder
           .scope("acceleration", builder =>
@@ -341,8 +322,6 @@ export const llmLlamaPredictionConfigSchematics = llmSharedPredictionConfigSchem
     "minPSampling",
     "topPSampling",
     "logProbs",
-    "speculativeDecoding.enabled",
-    "speculativeDecoding.draftModel",
     "speculativeDecoding.numberOfDraftTokens",
   ),
 );
@@ -357,6 +336,7 @@ export const llmMlxPredictionConfigSchematics = llmSharedPredictionConfigSchemat
     "repeatPenalty",
     "minPSampling",
     "topPSampling",
+    "speculativeDecoding.numberOfDraftTokens",
   ),
 );
 
@@ -379,11 +359,11 @@ export const llmSharedLoadConfigSchematics = llmLoadSchematics.sliced(
 const llamaLoadConfigSchematics = globalConfigSchematics.sliced("llama.load.*");
 
 export const llmLlamaLoadConfigSchematics = llmSharedLoadConfigSchematics
-  .union(llmLoadSchematics.sliced("llama.*"))
+  .union(llmLoadSchematics.sliced("llama.*", "speculativeDecoding.draftModel"))
   .union(llamaLoadConfigSchematics);
 
 export const llmMlxLoadConfigSchematics = llmSharedLoadConfigSchematics.union(
-  llmLoadSchematics.sliced("mlx.*"),
+  llmLoadSchematics.sliced("mlx.*", "speculativeDecoding.draftModel"),
 );
 
 export const llmOnnxLoadConfigSchematics = llmSharedLoadConfigSchematics.union(

--- a/packages/lms-kv-config/src/valueTypes.ts
+++ b/packages/lms-kv-config/src/valueTypes.ts
@@ -468,18 +468,6 @@ export const kvValueTypesLibrary = new KVFieldValueTypesLibraryBuilder({
       return JSON.stringify(value, null, 2); // TODO: pretty print
     },
   })
-  .valueType("speculativeDecodingEnabled", {
-    paramType: {},
-    schemaMaker: () => {
-      return z.boolean();
-    },
-    effectiveEquals: (a, b) => {
-      return a === b;
-    },
-    stringify: value => {
-      return value ? "ON" : "OFF";
-    },
-  })
   .valueType("speculativeDecodingDraftModel", {
     paramType: {},
     schemaMaker: () => {

--- a/packages/lms-shared-types/src/KVConfig.ts
+++ b/packages/lms-shared-types/src/KVConfig.ts
@@ -85,14 +85,20 @@ export const kvConfigStackSchema = z.object({
 
 export type KVConfigFieldDependency = {
   key: string;
-  condition: {
-    type: "equals";
-    value: any;
-  };
+  condition:
+    | {
+        type: "equals";
+        value: any;
+      }
+    | {
+        type: "notEquals";
+        value: any;
+      };
 };
 export const kvConfigFieldDependencySchema = z.object({
   key: z.string(),
   condition: z.discriminatedUnion("type", [
     z.object({ type: z.literal("equals"), value: z.any() }),
+    z.object({ type: z.literal("notEquals"), value: z.any() }),
   ]),
 }) as ZodSchema<KVConfigFieldDependency>;


### PR DESCRIPTION
Moves draft model to load parameters, removes 'speculative decoder enabled' field, adds a not equals comparison for dependencies (not used yet)