### PR TITLE
reasoning start and end can be string now

### DIFF
--- a/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
@@ -97,14 +97,14 @@ export function kvConfigToLLMPredictionConfig(config: KVConfig) {
     result.speculativeDecodingDraftTokensCount = speculativeDecodingDraftTokens;
   }
 
-  const reasoningStartToken = parsed.get("llm.prediction.reasoning.startToken");
-  if (reasoningStartToken !== undefined) {
-    result.reasoningStartToken = reasoningStartToken;
+  const reasoningStartString = parsed.get("llm.prediction.reasoning.startString");
+  if (reasoningStartString !== undefined) {
+    result.reasoningStartString = reasoningStartString;
   }
 
-  const reasoningEndToken = parsed.get("llm.prediction.reasoning.endToken");
-  if (reasoningEndToken !== undefined) {
-    result.reasoningEndToken = reasoningEndToken;
+  const reasoningEndString = parsed.get("llm.prediction.reasoning.endString");
+  if (reasoningEndString !== undefined) {
+    result.reasoningEndString = reasoningEndString;
   }
 
   return result;

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -131,8 +131,8 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
       )
       .scope("reasoning", builder =>
         builder
-          .field("startToken", "string", { isToken: true }, "<think>")
-          .field("endToken", "string", { isToken: true }, "</think>"),
+          .field("startString", "string", {}, "<think>")
+          .field("endString", "string", {}, "</think>"),
       )
       .scope("llama", builder =>
         builder

--- a/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
@@ -137,12 +137,12 @@ export interface LLMPredictionConfigInput<TStructuredOutputType = unknown> {
    * model. For example, "<think>" for DeepSeek R1. LM Studio will use this to parse reasoning
    * blocks.
    */
-  reasoningStartToken?: string;
+  reasoningStartString?: string;
   /**
    * The token that marks the end of a reasoning block. Must map to exactly one token in the model.
    * For example, "</think>" for DeepSeek R1. LM Studio will use this to parse reasoning blocks.
    */
-  reasoningEndToken?: string;
+  reasoningEndString?: string;
 }
 export const llmPredictionConfigInputSchema = z.object({
   maxPredictedTokens: z.number().int().min(-1).optional().or(z.literal(false)),
@@ -160,8 +160,8 @@ export const llmPredictionConfigInputSchema = z.object({
   promptTemplate: llmPromptTemplateSchema.optional(),
   speculativeDecodingDraftModelKey: z.string().optional(),
   speculativeDecodingDraftTokensCount: z.number().int().min(2).optional(),
-  reasoningStartToken: z.string().optional(),
-  reasoningEndToken: z.string().optional(),
+  reasoningStartString: z.string().optional(),
+  reasoningEndString: z.string().optional(),
 });
 
 export interface LLMPredictionConfig extends LLMPredictionConfigInput<any> {

--- a/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
@@ -133,14 +133,13 @@ export interface LLMPredictionConfigInput<TStructuredOutputType = unknown> {
    */
   speculativeDecodingDraftTokensCount?: number;
   /**
-   * The token that marks the beginning of a reasoning block. Must map to exactly one token in the
-   * model. For example, "<think>" for DeepSeek R1. LM Studio will use this to parse reasoning
-   * blocks.
+   * The string that marks the beginning of a reasoning block. For example, "<think>" for DeepSeek
+   * R1. LM Studio will use this to parse reasoning blocks.
    */
   reasoningStartString?: string;
   /**
-   * The token that marks the end of a reasoning block. Must map to exactly one token in the model.
-   * For example, "</think>" for DeepSeek R1. LM Studio will use this to parse reasoning blocks.
+   * The string that marks the end of a reasoning block. For example, "</think>" for DeepSeek R1. LM
+   * Studio will use this to parse reasoning blocks.
    */
   reasoningEndString?: string;
 }


### PR DESCRIPTION
We previously had the limitation that reasoning parsing start/end tags must be a single token. No longer!