### PR TITLE
Fix websocket server closing unexpectedly not handled

### DIFF
--- a/packages/lms-communication-client/src/WsClientTransport.ts
+++ b/packages/lms-communication-client/src/WsClientTransport.ts
@@ -82,6 +82,9 @@ export class WsClientTransport extends ClientTransport {
       this.ws = new WebSocket(url);
       this.ws.addEventListener("open", this.onWsOpen.bind(this));
       this.ws.addEventListener("error", event => this.onWsError(event.error));
+      this.ws.addEventListener("close", () => {
+        this.onWsError(new Error("WebSocket connection closed"));
+      });
 
       const abortSignal = this.abortSignal;
       if (abortSignal !== undefined) {


### PR DESCRIPTION
It is possible for the websocket server to fail in a way it closes the connection gracefully. In which case, we should also report an error because the closure is not expected.

The `onWsError` will only handle the error if the connection is not "disconnected". Thus when normally shutting down the connection/or encountering an actual error won't trigger this route as the connection will be marked as closed prior.