### PR TITLE
Add ModelFormatName

### DIFF
--- a/packages/lms-client/src/runtime/RuntimeNamespace.ts
+++ b/packages/lms-client/src/runtime/RuntimeNamespace.ts
@@ -6,6 +6,7 @@ import {
 } from "@lmstudio/lms-common";
 import { type RuntimePort } from "@lmstudio/lms-external-backend-interfaces";
 import {
+  type ModelFormatName,
   type RuntimeEngineInfo,
   type RuntimeEngineSelectionInfo,
   type RuntimeEngineSpecifier,
@@ -47,9 +48,12 @@ export class RuntimeEngineNamespace {
    * Select a runtime engine for a specific model format.
    * @public
    */
-  public async select(engine: RuntimeEngineSpecifier, modelFormat: string): Promise<void> {
+  public async select(
+    engine: RuntimeEngineSpecifier,
+    modelFormatName: ModelFormatName,
+  ): Promise<void> {
     const stack = getCurrentStack(1);
-    await this.runtimePort.callRpc("selectEngine", { engine, modelFormat }, { stack });
+    await this.runtimePort.callRpc("selectEngine", { engine, modelFormatName }, { stack });
   }
 
   /**

--- a/packages/lms-external-backend-interfaces/src/runtimeBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/runtimeBackendInterface.ts
@@ -1,6 +1,7 @@
 import { BackendInterface } from "@lmstudio/lms-communication";
 import { type InferClientPort } from "@lmstudio/lms-communication-client";
 import {
+  modelFormatNameSchema,
   runtimeEngineInfoSchema,
   runtimeEngineSelectionInfoSchema,
   runtimeEngineSpecifierSchema,
@@ -20,7 +21,7 @@ export function createRuntimeBackendInterface() {
     .addRpcEndpoint("selectEngine", {
       parameter: z.object({
         engine: runtimeEngineSpecifierSchema,
-        modelFormat: z.string(),
+        modelFormatName: modelFormatNameSchema,
       }),
       returns: z.void(),
     })

--- a/packages/lms-shared-types/src/RuntimeEngine.ts
+++ b/packages/lms-shared-types/src/RuntimeEngine.ts
@@ -1,6 +1,15 @@
 import { z, type ZodSchema } from "zod";
 
 /**
+ * Supported model formats
+ *
+ * @public
+ */
+export type ModelFormatName = "GGUF" | "MLX";
+
+export const modelFormatNameSchema = z.enum(["GGUF", "MLX"]);
+
+/**
  * Uniquely specifies a Runtime Engine
  *
  * @public
@@ -35,7 +44,7 @@ export interface RuntimeEngineInfo extends RuntimeEngineSpecifier {
     make?: string;
     framework?: string;
   };
-  supportedModelFormats: string[];
+  supportedModelFormatNames: ModelFormatName[];
 }
 export const runtimeEngineInfoSchema = runtimeEngineSpecifierSchemaBase.extend({
   engine: z.string(),
@@ -50,7 +59,7 @@ export const runtimeEngineInfoSchema = runtimeEngineSpecifierSchemaBase.extend({
       framework: z.string().optional(),
     })
     .optional(),
-  supportedModelFormats: z.array(z.string()),
+  supportedModelFormatNames: z.array(modelFormatNameSchema),
 }) as ZodSchema<RuntimeEngineInfo>;
 
 /**
@@ -59,8 +68,8 @@ export const runtimeEngineInfoSchema = runtimeEngineSpecifierSchemaBase.extend({
  * @public
  */
 export interface RuntimeEngineSelectionInfo extends RuntimeEngineSpecifier {
-  modelFormats: string[];
+  modelFormatNames: ModelFormatName[];
 }
 export const runtimeEngineSelectionInfoSchema = runtimeEngineSpecifierSchemaBase.extend({
-  modelFormats: z.array(z.string()),
+  modelFormatNames: z.array(modelFormatNameSchema),
 }) as ZodSchema<RuntimeEngineSelectionInfo>;

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -359,14 +359,6 @@ export { PresetManifest, presetManifestSchema } from "./PresetManifest.js";
 export { reasonableKeyStringSchema } from "./reasonable.js";
 export { RemotePluginInfo, remotePluginInfoSchema } from "./RemotePluginInfo.js";
 export {
-  hubModelMetadataSchema,
-  hubModelSchema,
-  hubArtifactSchema,
-  HubModel,
-  HubModelMetadata,
-  HubArtifact,
-} from "./repository/HubArtifact.js";
-export {
   ArtifactDownloadPlan,
   ArtifactDownloadPlanModelInfo,
   artifactDownloadPlanModelInfoSchema,
@@ -386,6 +378,14 @@ export {
   DownloadProgressUpdate,
   downloadProgressUpdateSchema,
 } from "./repository/DownloadProgressUpdate.js";
+export {
+  HubArtifact,
+  hubArtifactSchema,
+  HubModel,
+  HubModelMetadata,
+  hubModelMetadataSchema,
+  hubModelSchema,
+} from "./repository/HubArtifact.js";
 export {
   ModelSearchOpts,
   modelSearchOptsSchema,
@@ -423,6 +423,8 @@ export {
   runtimeSchema,
 } from "./Runtime.js";
 export {
+  ModelFormatName,
+  modelFormatNameSchema,
   RuntimeEngineInfo,
   runtimeEngineInfoSchema,
   RuntimeEngineSelectionInfo,

--- a/publish/sdk/src/exportedTypes.ts
+++ b/publish/sdk/src/exportedTypes.ts
@@ -176,6 +176,7 @@ export type {
   ModelCompatibilityType,
   ModelDomainType,
   ModelDownloadSource,
+  ModelFormatName,
   ModelInfo,
   ModelInfoBase,
   ModelInstanceInfo,


### PR DESCRIPTION
Add `ModelFormatName`, a union of strings, to give clarity on the client side for what model formats are valid.

The commit has been reverted on main, but will be restored later. This PR is against the pre-revert commit so that it is easier to review.