### PR TITLE
Allow passing in api token environment variable

### DIFF
--- a/packages/lms-client/src/LMStudioClient.ts
+++ b/packages/lms-client/src/LMStudioClient.ts
@@ -382,12 +382,12 @@ export class LMStudioClient {
     }
 
     if (
-      process.env.LMSTUDIO_API_TOKEN !== undefined &&
-      process.env.LMSTUDIO_API_TOKEN !== "" &&
+      process.env.LM_API_TOKEN !== undefined &&
+      process.env.LM_API_TOKEN !== "" &&
       (clientIdentifier !== undefined || clientPasskey !== undefined)
     ) {
       throw new Error(text`
-        You cannot set LMSTUDIO_API_TOKEN environment variable and pass in
+        You cannot set LM_API_TOKEN environment variable and pass in
         clientIdentifier/clientPasskey. clientIdentifier and clientPasskey are legacy
         authentication methods and have been replaced by apiToken.
       `);
@@ -409,14 +409,11 @@ export class LMStudioClient {
       }
       clientIdentifier = match.groups.clientIdentifier;
       clientPasskey = match.groups.clientPasskey;
-    } else if (
-      process.env.LMSTUDIO_API_TOKEN !== undefined &&
-      process.env.LMSTUDIO_API_TOKEN !== ""
-    ) {
-      const match = process.env.LMSTUDIO_API_TOKEN.match(lmstudioAPITokenRegex);
+    } else if (process.env.LM_API_TOKEN !== undefined && process.env.LM_API_TOKEN !== "") {
+      const match = process.env.LM_API_TOKEN.match(lmstudioAPITokenRegex);
       if (match === null) {
         throw new Error(text`
-          The LMSTUDIO_API_TOKEN environment variable does not look like a valid LM Studio API
+          The LM_API_TOKEN environment variable does not look like a valid LM Studio API
           token.
 
           LM Studio API tokens are obtained from LM Studio, and they look like this:


### PR DESCRIPTION
Allow passing in the LM Studio API token via environment variable `LMSTUDIO_API_TOKEN`.