### PR TITLE
Add image resize settings

### DIFF
--- a/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
@@ -141,6 +141,11 @@ export function kvConfigToLLMPredictionConfig(
     result.reasoningParsing = reasoningParsing;
   }
 
+  const imageResize = parsed.get("vision.imageResizeSettings");
+  if (imageResize !== undefined) {
+    result.imageResize = imageResize;
+  }
+
   result.raw = config;
 
   return result;
@@ -173,6 +178,7 @@ export function llmPredictionConfigToKVConfig(config: LLMPredictionConfig): KVCo
     "speculativeDecoding.minContinueDraftingProbability":
       config.speculativeDecodingMinContinueDraftingProbability,
     "reasoning.parsing": config.reasoningParsing,
+    "vision.imageResizeSettings": config.imageResize,
   });
   if (config.raw !== undefined) {
     return collapseKVStackRaw([config.raw, top]);

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -171,6 +171,14 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
           },
         ),
       )
+      .scope("vision", builder =>
+        builder.field(
+          "imageResizeSettings",
+          "imageResizeSettings",
+          {},
+          { maxWidth: 500, maxHeight: 500 },
+        ),
+      )
       .scope("llama", builder =>
         builder
           .field("cpuThreads", "numeric", { min: 1, int: true }, 4)
@@ -379,6 +387,7 @@ export const llmSharedPredictionConfigSchematics = llmPredictionConfigSchematics
   "toolChoice",
   "toolNaming",
   "reasoning.*",
+  "vision.*",
 );
 
 export const llmLlamaPredictionConfigSchematics = llmSharedPredictionConfigSchematics.union(

--- a/packages/lms-kv-config/src/valueTypes.ts
+++ b/packages/lms-kv-config/src/valueTypes.ts
@@ -1,6 +1,7 @@
 import {
   allowableEnvVarsSchema,
   gpuSplitConfigSchema,
+  imageResizeSettingsSchema,
   kvConfigFieldDependencySchema,
   llmContextOverflowPolicySchema,
   llmContextReferenceSchema,
@@ -635,6 +636,18 @@ export const kvValueTypesLibrary = baseKVValueTypesLibraryBuilder
     },
     stringify: value => {
       return value;
+    },
+  })
+  .valueType("imageResizeSettings", {
+    paramType: {},
+    schemaMaker: () => {
+      return imageResizeSettingsSchema;
+    },
+    effectiveEquals: (a, b) => {
+      return a.maxWidth === b.maxWidth && a.maxHeight === b.maxHeight;
+    },
+    stringify: value => {
+      return JSON.stringify(value, null, 2); // TODO: pretty print
     },
   })
   .valueType("llamaAccelerationOffloadRatio", {

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -138,6 +138,7 @@ export {
   kvConfigStackSchema,
 } from "./KVConfig.js";
 export { ContentBlockStyle, contentBlockStyleSchema } from "./llm/ContentBlockStyle.js";
+export { ImageResizeSettings, imageResizeSettingsSchema } from "./llm/ImageResizeSettings.js";
 export {
   LLMApplyPromptTemplateOpts,
   llmApplyPromptTemplateOptsSchema,

--- a/packages/lms-shared-types/src/llm/ImageResizeSettings.ts
+++ b/packages/lms-shared-types/src/llm/ImageResizeSettings.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+/**
+ * Controls how images are resized before being sent to the LLM.
+ *
+ * @experimental [EXP-IMAGE-RESIZE] Image resize settings are experimental and may change in the
+ * future.
+ * @public
+ */
+export interface ImageResizeSettings {
+  maxWidth: number;
+  maxHeight: number;
+}
+export const imageResizeSettingsSchema = z.object({
+  maxWidth: z.number().int().positive(),
+  maxHeight: z.number().int().positive(),
+});

--- a/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
@@ -2,6 +2,7 @@ import { z, type ZodSchema } from "zod";
 import { kvConfigSchema, type KVConfig } from "../KVConfig.js";
 import { toolNamingSchema, type ToolNaming } from "../ToolNaming.js";
 import { zodSchemaSchema } from "../Zod.js";
+import { imageResizeSettingsSchema, type ImageResizeSettings } from "./ImageResizeSettings.js";
 import { llmPromptTemplateSchema, type LLMPromptTemplate } from "./LLMPromptTemplate.js";
 import {
   llmStructuredPredictionSettingSchema,
@@ -287,6 +288,14 @@ export interface LLMPredictionConfigInput<TStructuredOutputType = unknown> {
    */
   reasoningParsing?: LLMReasoningParsing;
   /**
+   * Controls how images are resized before being sent to the LLM.
+   *
+   * @experimental [EXP-IMAGE-RESIZE] Image resize settings are experimental and may change in the
+   * future.
+   * @public
+   */
+  imageResize?: ImageResizeSettings;
+  /**
    * Raw KV Config.
    *
    * @experimental
@@ -316,6 +325,7 @@ export const llmPredictionConfigInputSchema = z.object({
   speculativeDecodingMinDraftLengthToConsider: z.number().int().min(0).optional(),
   speculativeDecodingMinContinueDraftingProbability: z.number().optional(),
   reasoningParsing: llmReasoningParsingSchema.optional(),
+  imageResize: imageResizeSettingsSchema.optional(),
   raw: kvConfigSchema.optional(),
 });
 


### PR DESCRIPTION
Allow controlling how much images are being resized when used with vision models. Note, the exact type is not finalized yet.