### PR TITLE
Use provided client id/passkey over env var token

### DIFF
--- a/packages/lms-client/src/LMStudioClient.ts
+++ b/packages/lms-client/src/LMStudioClient.ts
@@ -397,6 +397,8 @@ export class LMStudioClient {
       }
       clientIdentifier = match.groups.clientIdentifier;
       clientPasskey = match.groups.clientPasskey;
+    } else if (clientIdentifier !== undefined || clientPasskey !== undefined) {
+      // Use provided legacy clientIdentifier/clientPasskey as-is (precedence over env var)
     } else if (process.env.LM_API_TOKEN !== undefined && process.env.LM_API_TOKEN !== "") {
       const match = process.env.LM_API_TOKEN.match(lmstudioAPITokenRegex);
       if (match === null) {


### PR DESCRIPTION
Auth precedence:
1) if apiToken is provided, use that
2) if clientIdentifier/clientPasskey provided, use those
3) if LM_API_TOKEN env var is set, use that
4) else generate random identifier/passkey

