### PR TITLE
Added listAvailable() method to LLMNamespace and EmbeddingNamespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lms",
       "version": "1.0.0",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
       "workspaces": [
         "packages/*",
         "publish/*",
@@ -23165,7 +23165,7 @@
       "name": "@lmstudio/lms-cli",
       "version": "0.3.43",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
         "@lmstudio/lms-common": "^0.8.9",
@@ -23641,7 +23641,6 @@
       "dependencies": {
         "@lmstudio/lms-common": "^0.8.9",
         "@lmstudio/lms-common-server": "^0.2.18",
-        "boxen": "^5.1.2",
         "chalk": "^4.1.2",
         "inquirer": "^8.2.6"
       },
@@ -23855,7 +23854,7 @@
     "publish/sdk": {
       "name": "@lmstudio/sdk",
       "version": "1.5.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@lmstudio/lms-isomorphic": "^0.4.6",
         "chalk": "^4.1.2",

--- a/packages/lms-client/src/embedding/EmbeddingNamespace.ts
+++ b/packages/lms-client/src/embedding/EmbeddingNamespace.ts
@@ -48,4 +48,26 @@ export class EmbeddingNamespace extends ModelNamespace<
   ): EmbeddingDynamicHandle {
     return new EmbeddingDynamicHandle(port, specifier, validator, logger);
   }
+
+  /**
+   * List all available (downloaded) embedding models.
+   *
+   * This is a convenience method that returns all downloaded embedding models. It's equivalent to
+   * calling `client.system.listDownloadedModels("embedding")`.
+   *
+   * @example
+   * ```ts
+   * const availableModels = await client.embedding.listAvailable();
+   * console.log(`Found ${availableModels.length} available embedding models`);
+   * for (const model of availableModels) {
+   *   console.log(`- ${model.displayName} (${model.modelKey})`);
+   * }
+   * ```
+   *
+   * @returns A promise that resolves to an array of available embedding model information
+   * @public
+   */
+  public async listAvailable(): Promise<Array<EmbeddingModelInfo>> {
+    return await this.client.system.listDownloadedModels("embedding");
+  }
 }

--- a/packages/lms-client/src/llm/LLMNamespace.ts
+++ b/packages/lms-client/src/llm/LLMNamespace.ts
@@ -48,4 +48,26 @@ export class LLMNamespace extends ModelNamespace<
   ): LLMDynamicHandle {
     return new LLMDynamicHandle(port, specifier, validator, logger);
   }
+
+  /**
+   * List all available (downloaded) LLM models.
+   *
+   * This is a convenience method that returns all downloaded LLM models. It's equivalent to
+   * calling `client.system.listDownloadedModels("llm")`.
+   *
+   * @example
+   * ```ts
+   * const availableModels = await client.llm.listAvailable();
+   * console.log(`Found ${availableModels.length} available LLM models`);
+   * for (const model of availableModels) {
+   *   console.log(`- ${model.displayName} (${model.modelKey})`);
+   * }
+   * ```
+   *
+   * @returns A promise that resolves to an array of available LLM model information
+   * @public
+   */
+  public async listAvailable(): Promise<Array<LLMInfo>> {
+    return await this.client.system.listDownloadedModels("llm");
+  }
 }


### PR DESCRIPTION
- Add listAvailable() method to LLMNamespace for listing downloaded LLM models
- Add listAvailable() method to EmbeddingNamespace for listing downloaded embedding models This provides easier check of all downloaded models in the system