### PR TITLE
Ignore server session config when dynamic handle ignores it

### DIFF
--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -444,9 +444,6 @@ export class LLMDynamicHandle extends DynamicHandle<
   private readonly internalKVConfigStack: KVConfigStack = { layers: [] };
 
   /** @internal */
-  private readonly internalIgnoreServerSessionConfig: boolean | undefined = undefined;
-
-  /** @internal */
   private internalPredict(
     history: ChatHistoryData,
     predictionConfigStack: KVConfigStack,

--- a/packages/lms-client/src/modelShared/DynamicHandle.ts
+++ b/packages/lms-client/src/modelShared/DynamicHandle.ts
@@ -1,10 +1,10 @@
 import { getCurrentStack } from "@lmstudio/lms-common";
 import { type BaseModelPort } from "@lmstudio/lms-external-backend-interfaces";
 import {
-  type ModelProcessingState,
   type KVConfig,
   type ModelInfoBase,
   type ModelInstanceInfoBase,
+  type ModelProcessingState,
   type ModelSpecifier,
 } from "@lmstudio/lms-shared-types";
 
@@ -36,6 +36,9 @@ export abstract class DynamicHandle<
     /** @internal */
     protected readonly specifier: ModelSpecifier,
   ) {}
+
+  /** @internal */
+  protected readonly internalIgnoreServerSessionConfig: boolean | undefined = undefined;
 
   /**
    * Gets the information of the model that is currently associated with this `DynamicHandle`. If no
@@ -77,7 +80,10 @@ export abstract class DynamicHandle<
   protected async getBasePredictionKVConfig(stack: string): Promise<KVConfig> {
     const basePredictionConfig = await this.port.callRpc(
       "getBasePredictionConfig",
-      { specifier: this.specifier },
+      {
+        specifier: this.specifier,
+        ignoreServerSessionConfig: this.internalIgnoreServerSessionConfig,
+      },
       { stack },
     );
     return basePredictionConfig;

--- a/packages/lms-external-backend-interfaces/src/baseModelBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/baseModelBackendInterface.ts
@@ -95,6 +95,7 @@ export function createBaseModelBackendInterface<
     .addRpcEndpoint("getBasePredictionConfig", {
       parameter: z.object({
         specifier: modelSpecifierSchema,
+        ignoreServerSessionConfig: z.boolean().optional(),
       }),
       returns: kvConfigSchema,
     })


### PR DESCRIPTION
If the handle is configured to bypass server config, pass along the flag.