### PR TITLE
Add stop string in the prediction stat

### DIFF
--- a/packages/lms-shared-types/src/llm/LLMPredictionStats.ts
+++ b/packages/lms-shared-types/src/llm/LLMPredictionStats.ts
@@ -82,6 +82,7 @@ export interface LLMPredictionStats {
   stopReason: LLMPredictionStopReason;
   /**
    * The stop string that ended the prediction when stopReason is stopStringFound.
+   * This will be undefined if stopReason is not stopStringFound.
    */
   stopString?: string;
   /**


### PR DESCRIPTION
## Overview

Adds a new field to `LLMPredictionStats` to add `stopString` which is the string the LLM encountered to stop if stop strings were provided