### PR TITLE
Remote plugin in via LM Link

### DIFF
--- a/packages/lms-client/src/plugins/processing/ProcessingController.ts
+++ b/packages/lms-client/src/plugins/processing/ProcessingController.ts
@@ -1,6 +1,7 @@
 import { Cleaner, raceWithAbortSignal, type SimpleLogger } from "@lmstudio/lms-common";
 import { type PluginsPort } from "@lmstudio/lms-external-backend-interfaces";
 import {
+  type AvailablePluginInfo,
   type ChatMessageRoleData,
   type ContentBlockStyle,
   type KVConfig,
@@ -9,7 +10,6 @@ import {
   type ProcessingRequest,
   type ProcessingRequestResponse,
   type ProcessingUpdate,
-  type RemotePluginInfo,
   type StatusStepState,
   type TokenSourceIdentifier,
   type ToolStatusStepStateStatus,
@@ -204,7 +204,7 @@ export class ProcessingController extends BaseController {
     pluginConfig: KVConfig,
     globalPluginConfig: KVConfig,
     workingDirectoryPath: string | null,
-    private readonly enabledPluginInfos: Array<RemotePluginInfo>,
+    private readonly enabledPluginInfos: Array<AvailablePluginInfo>,
     /** @internal */
     private readonly connector: ProcessingConnector,
     /** @internal */

--- a/packages/lms-external-backend-interfaces/src/pluginsBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/pluginsBackendInterface.ts
@@ -1,6 +1,7 @@
 import { BackendInterface } from "@lmstudio/lms-communication";
 import { type InferClientPort } from "@lmstudio/lms-communication-client";
 import {
+  availablePluginInfoSchema,
   chatHistoryDataSchema,
   chatMessageDataSchema,
   jsonSerializableSchema,
@@ -8,13 +9,12 @@ import {
   llmPredictionFragmentInputOptsSchema,
   llmPredictionFragmentSchema,
   llmToolSchema,
-  promptProcessingDetailsSchema,
   pluginConfigSpecifierSchema,
   pluginManifestSchema,
   processingRequestResponseSchema,
   processingRequestSchema,
   processingUpdateSchema,
-  remotePluginInfoSchema,
+  promptProcessingDetailsSchema,
   serializedKVConfigSchematicsSchema,
   serializedLMSExtendedErrorSchema,
   tokenSourceIdentifierSchema,
@@ -218,7 +218,7 @@ export function createPluginsBackendInterface() {
             /**
              * An array of all the plugins that are enabled for this prediction.
              */
-            enabledPluginInfos: z.array(remotePluginInfoSchema),
+            enabledPluginInfos: z.array(availablePluginInfoSchema),
             /** Processing Context Identifier */
             pci: z.string(),
             token: z.string(),
@@ -258,7 +258,7 @@ export function createPluginsBackendInterface() {
             /**
              * An array of all the plugins that are enabled for this prediction.
              */
-            enabledPluginInfos: z.array(remotePluginInfoSchema),
+            enabledPluginInfos: z.array(availablePluginInfoSchema),
             /** Processing Context Identifier */
             pci: z.string(),
             token: z.string(),

--- a/packages/lms-shared-types/src/AvailablePluginInfo.ts
+++ b/packages/lms-shared-types/src/AvailablePluginInfo.ts
@@ -8,7 +8,7 @@ import { z, type ZodSchema } from "zod";
  *
  * @public
  */
-export interface RemotePluginInfo {
+export interface AvailablePluginInfo {
   /**
    * The identifier of the plugin. For non-dev plugins, this is the same as the artifact identifier
    * when uploaded to LM Studio Hub. For example, `lmstudio/dice`.
@@ -44,7 +44,7 @@ export interface RemotePluginInfo {
    */
   hasGenerator: boolean;
 }
-export const remotePluginInfoSchema = z.object({
+export const availablePluginInfoSchema = z.object({
   identifier: z.string(),
   isDev: z.boolean(),
   isTrusted: z.boolean(),
@@ -52,4 +52,4 @@ export const remotePluginInfoSchema = z.object({
   hasPredictionLoopHandler: z.boolean(),
   hasToolsProvider: z.boolean(),
   hasGenerator: z.boolean(),
-}) as ZodSchema<RemotePluginInfo>;
+}) as ZodSchema<AvailablePluginInfo>;

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -27,6 +27,10 @@ export {
   ArtifactModelDependency,
   artifactModelDependencySchema,
 } from "./ArtifactManifestBase.js";
+export {
+  AvailablePluginInfo as AvailablePluginInfo,
+  availablePluginInfoSchema,
+} from "./AvailablePluginInfo.js";
 export { BackendNotification, backendNotificationSchema } from "./BackendNotification.js";
 export {
   ChatHistoryData,
@@ -402,7 +406,6 @@ export {
 } from "./ProjectYaml.js";
 export { Quantization, quantizationSchema } from "./Quantization.js";
 export { reasonableKeyStringSchema } from "./reasonable.js";
-export { RemotePluginInfo, remotePluginInfoSchema } from "./RemotePluginInfo.js";
 export {
   ArtifactDownloadPlan,
   ArtifactDownloadPlanModelInfo,


### PR DESCRIPTION
Rename `RemotePluginInfo` to `AvailablePluginInfo` to avoid confusion with remote plugins via LM Link.

Not breaking change since `RemotePluginInfo` was not and still not stabilized yet.