### PR TITLE
Add llama physical batch size config

### DIFF
--- a/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
@@ -104,6 +104,11 @@ function kvConfigToLLMLlamaLoadModelConfig(
     result.evalBatchSize = evalBatchSize;
   }
 
+  const physicalBatchSize = parsed.get("llama.physicalBatchSize");
+  if (physicalBatchSize !== undefined) {
+    result.physicalBatchSize = physicalBatchSize;
+  }
+
   const flashAttention = parsed.get("llama.flashAttention");
   if (flashAttention !== undefined) {
     result.flashAttention = flashAttention;
@@ -237,6 +242,7 @@ export function llmLoadModelConfigToKVConfig(config: LLMLoadModelConfig): KVConf
     "llama.ropeFrequencyBase": maybeFalseValueToCheckboxValue(config.ropeFrequencyBase, 0),
     "llama.ropeFrequencyScale": maybeFalseValueToCheckboxValue(config.ropeFrequencyScale, 0),
     "llama.evalBatchSize": config.evalBatchSize,
+    "llama.physicalBatchSize": config.physicalBatchSize,
     "llama.flashAttention": config.flashAttention,
     "llama.speculativeDecoding.draftMtp": config.speculativeDraftMtp,
     "llama.speculativeDecoding.draftMtpMaxTokens": config.speculativeDraftMtpMaxTokens,

--- a/packages/lms-kv-config/src/schema.test.ts
+++ b/packages/lms-kv-config/src/schema.test.ts
@@ -70,6 +70,30 @@ describe("llmLoadModelConfig conversion", () => {
     expect(roundTrippedConfig.speculativeDraftMtpMaxTokens).toBe(3);
     expect(roundTrippedConfig.speculativeDraftMtpMinTokens).toBe(0);
   });
+
+  it("round trips llama physical batch size", () => {
+    const loadConfig = llmLoadModelConfigToKVConfig({
+      evalBatchSize: 512,
+      physicalBatchSize: 256,
+    });
+
+    const roundTrippedConfig = kvConfigToLLMLoadModelConfig(loadConfig);
+
+    expect(roundTrippedConfig.evalBatchSize).toBe(512);
+    expect(roundTrippedConfig.physicalBatchSize).toBe(256);
+  });
+
+  it("does not expose llama physical batch size for MLX load configs", () => {
+    const loadConfig = llmLoadModelConfigToKVConfig({
+      physicalBatchSize: 256,
+    });
+
+    const roundTrippedConfig = kvConfigToLLMLoadModelConfig(loadConfig, {
+      modelFormat: "safetensors",
+    });
+
+    expect(roundTrippedConfig.physicalBatchSize).toBeUndefined();
+  });
 });
 
 describe("globalConfigSchematics", () => {

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -301,6 +301,17 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
           )
           .field("cpuThreadPoolSize", "numeric", { min: 1, machineDependent: true }, 4)
           .field("evalBatchSize", "numeric", { min: 1, int: true }, 512)
+          .field(
+            "physicalBatchSize",
+            "numeric",
+            {
+              min: 1,
+              int: true,
+              displayName: "Physical Batch Size",
+              subtitle: "Maximum number of prompt tokens to process physically at a time",
+            },
+            512,
+          )
           .field("flashAttention", "boolean", {}, false)
           .scope("speculativeDecoding", builder =>
             builder

--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -222,6 +222,14 @@ export interface LLMLoadModelConfig {
   evalBatchSize?: number;
 
   /**
+   * Maximum number of prompt tokens to process physically at a time.
+   *
+   * This advanced llama.cpp setting controls the physical batch size used for internal prompt
+   * processing. It is clamped by the evaluation batch size.
+   */
+  physicalBatchSize?: number;
+
+  /**
    * Enables Flash Attention for optimized attention computation.
    *
    * Flash Attention is an efficient implementation that reduces memory usage and speeds up
@@ -364,6 +372,7 @@ export const llmLoadModelConfigSchema = z.object({
   ropeFrequencyBase: z.number().or(z.literal(false)).optional(),
   ropeFrequencyScale: z.number().or(z.literal(false)).optional(),
   evalBatchSize: z.number().int().min(1).optional(),
+  physicalBatchSize: z.number().int().min(1).optional(),
   flashAttention: z.boolean().optional(),
   speculativeDraftMtp: z.boolean().optional(),
   speculativeDraftMtpMaxTokens: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Summary
- add physicalBatchSize to llama load model config types and validation
- expose llm.load.llama.physicalBatchSize next to evalBatchSize
- round-trip the field through KV config conversion while keeping it out of MLX load configs

## Testing
- npx jest packages/lms-kv-config/src/schema.test.ts --runInBand
- Verified through llmster daemon/runtime integration with default and explicit llama n_ubatch values