### PR TITLE
Align physical batch size help metadata

### DIFF
--- a/packages/lms-kv-config/src/schema.test.ts
+++ b/packages/lms-kv-config/src/schema.test.ts
@@ -97,6 +97,15 @@ describe("llmLoadModelConfig conversion", () => {
 });
 
 describe("globalConfigSchematics", () => {
+  it("uses 2048 as the default llama eval batch size", () => {
+    const emptyConfig = makeKVConfigFromFields([]);
+
+    expect(globalConfigSchematics.access(emptyConfig, "llm.load.llama.evalBatchSize")).toBe(2048);
+    expect(globalConfigSchematics.access(emptyConfig, "embedding.load.llama.evalBatchSize")).toBe(
+      2048,
+    );
+  });
+
   it("makes speculative decoding draft-token settings depend on a draft model", () => {
     const dependentConfigKeys = [
       "llm.prediction.speculativeDecoding.minDraftLengthToConsider",

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -308,7 +308,6 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
               min: 1,
               int: true,
               displayName: "Physical Batch Size",
-              subtitle: "Maximum number of prompt tokens to process physically at a time",
             },
             512,
           )

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -300,7 +300,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
             ),
           )
           .field("cpuThreadPoolSize", "numeric", { min: 1, machineDependent: true }, 4)
-          .field("evalBatchSize", "numeric", { min: 1, int: true }, 512)
+          .field("evalBatchSize", "numeric", { min: 1, int: true }, 2048)
           .field(
             "physicalBatchSize",
             "numeric",
@@ -411,7 +411,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
               "max",
             ),
           )
-          .field("evalBatchSize", "numeric", { min: 1, int: true }, 512)
+          .field("evalBatchSize", "numeric", { min: 1, int: true }, 2048)
           .field(
             "ropeFrequencyBase",
             "checkboxNumeric",


### PR DESCRIPTION
## Summary
- Remove the physical batch size schema subtitle so the UI uses localized help text like eval batch size.
- Bump default eval batch size to 2048 now that eval batch size is 512.

## Test
- npm run build
- node runtime schema check