### PR TITLE
Add enableThinking as a predictionConfig for LSEP

### DIFF
--- a/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
@@ -110,6 +110,11 @@ export function kvConfigToLLMPredictionConfig(
     result.cpuThreads = cpuThreads;
   }
 
+  const enableThinking = parsed.get("reasoning.enableThinking");
+  if (enableThinking !== undefined) {
+    result.enableThinking = enableThinking;
+  }
+
   const promptTemplate = parsed.get("promptTemplate");
   if (promptTemplate !== undefined) {
     result.promptTemplate = promptTemplate;
@@ -185,6 +190,7 @@ export function llmPredictionConfigToKVConfig(config: LLMPredictionConfig): KVCo
     "llama.xtcThreshold": maybeFalseValueToCheckboxValue(config.xtcThreshold, 0),
     "logProbs": maybeFalseValueToCheckboxValue(config.logProbs, 0),
     "llama.cpuThreads": config.cpuThreads,
+    "reasoning.enableThinking": config.enableThinking,
     "promptTemplate": config.promptTemplate,
     "speculativeDecoding.draftModel": config.draftModel,
     "speculativeDecoding.numDraftTokensExact": config.speculativeDecodingNumDraftTokensExact,

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -184,16 +184,26 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
         { checked: false, value: 0 },
       )
       .scope("reasoning", builder =>
-        builder.field(
-          "parsing",
-          "llmReasoningParsing",
-          {},
-          {
-            enabled: true,
-            startString: "<think>",
-            endString: "</think>",
-          },
-        ),
+        builder
+          .field(
+            "enableThinking",
+            "boolean",
+            {
+              displayName: "Enable Thinking",
+              subtitle: "Controls thinking for chat templates that support enable_thinking.",
+            },
+            true,
+          )
+          .field(
+            "parsing",
+            "llmReasoningParsing",
+            {},
+            {
+              enabled: true,
+              startString: "<think>",
+              endString: "</think>",
+            },
+          ),
       )
       .scope("vision", builder =>
         builder

--- a/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
@@ -233,6 +233,12 @@ export interface LLMPredictionConfigInput<TStructuredOutputType = unknown> {
    */
   cpuThreads?: number;
   /**
+   * Controls thinking for Llama chat templates that support `enable_thinking`.
+   *
+   * @experimental
+   */
+  enableThinking?: boolean;
+  /**
    * Defines a custom template for formatting prompts before sending them to the model.
    *
    * Prompt templates allow you to control exactly how conversations are formatted, including
@@ -345,6 +351,7 @@ export const llmPredictionConfigInputSchema = z.object({
   minPSampling: z.number().optional().or(z.literal(false)),
   topPSampling: z.number().optional().or(z.literal(false)),
   cpuThreads: z.number().int().optional(),
+  enableThinking: z.boolean().optional(),
   promptTemplate: llmPromptTemplateSchema.optional(),
   draftModel: z.string().optional(),
   speculativeDecodingNumDraftTokensExact: z.number().int().min(1).optional(),


### PR DESCRIPTION
## Overview

Adds `enableThinking` to LLMPredictionConfig 

Did not choose to add it under `llama` as in the future we might want to get this in for MLX too, but currently is scoped for llama-LSEP only