### PR TITLE
Add TurboQuant KV cache quantization types (turbo2/turbo3/turbo4)

### DIFF
--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -77,9 +77,16 @@ export const llmLlamaCacheQuantizationTypes = [
   "iq4_nl",
   "q5_0",
   "q5_1",
+  "turbo2",
+  "turbo3",
+  "turbo4",
 ] as const;
 /**
- * TODO: Add documentation
+ * TurboQuant KV cache compression (ICLR 2026, arXiv:2504.19874).
+ * See https://github.com/0xSero/turboquant and https://github.com/TheTom/turboquant_plus
+ * - turbo2: 2-bit PolarQuant + WHT rotation, 6.4x compression
+ * - turbo3: 3-bit PolarQuant + WHT rotation, 4.6x compression
+ * - turbo4: 4-bit PolarQuant + WHT rotation, 3.8x compression
  *
  * @public
  */
@@ -91,7 +98,10 @@ export type LLMLlamaCacheQuantizationType =
   | "q4_1"
   | "iq4_nl"
   | "q5_0"
-  | "q5_1";
+  | "q5_1"
+  | "turbo2"
+  | "turbo3"
+  | "turbo4";
 export const llmLlamaCacheQuantizationTypeSchema = z.enum(llmLlamaCacheQuantizationTypes);
 
 // MLX KV cache quantization


### PR DESCRIPTION
## Summary

Add support for TurboQuant KV cache compression types to `LLMLlamaCacheQuantizationType`.

## Changes

Added `"turbo2"`, `"turbo3"`, and `"turbo4"` to:
- `llmLlamaCacheQuantizationTypes` array
- `LLMLlamaCacheQuantizationType` type union
- `llmLlamaCacheQuantizationTypeSchema` zod enum

## Details

TurboQuant (ICLR 2026, arXiv:2504.19874) is a KV cache compression method using PolarQuant + Walsh-Hadamard rotation for near-lossless key compression at 3-bit (cos_sim=1.0). Compression ratios:
- `turbo2`: 2-bit, 6.4x compression
- `turbo3`: 3-bit, 4.6x compression  
- `turbo4`: 4-bit, 3.8x compression

These map to the `--cache-type-k/turbo3 --cache-type-v/turbo3` flags in llama.cpp with TurboQuant+ support ([TheTom/turboquant_plus](https://github.com/TheTom/turboquant_plus)).

## References
- Issue #1719 on lmstudio-bug-tracker: Feature Request for TurboQuant+ KV Cache Compression
- https://github.com/TheTom/turboquant_plus
- https://github.com/0xSero/turboquant