### PR TITLE
Remove load-time prompt template stop strings

### DIFF
--- a/packages/lms-client/src/llm/loadPromptTemplateConfig.test.ts
+++ b/packages/lms-client/src/llm/loadPromptTemplateConfig.test.ts
@@ -36,7 +36,6 @@ const customLoadPromptTemplate: NonNullable<LLMLoadModelConfig["promptTemplate"]
   jinjaPromptTemplate: {
     template: "{% for message in messages %}{{ message.content }}{% endfor %}",
   },
-  stopStrings: ["<load-stop>"],
 };
 
 const predictionPromptTemplate: NonNullable<LLMPredictionConfig["promptTemplate"]> = {

--- a/packages/lms-kv-config/src/schema.test.ts
+++ b/packages/lms-kv-config/src/schema.test.ts
@@ -378,24 +378,6 @@ describe("globalConfigSchematics", () => {
     );
   });
 
-  it("ignores beta load-time prompt template stop strings", () => {
-    const promptTemplate = {
-      type: "jinja" as const,
-      jinjaPromptTemplate: {
-        template: "{% for message in messages %}{{ message.content }}{% endfor %}",
-      },
-    };
-    const loadConfig = makeKVConfigFromFields([
-      kvConfigField("llm.load.promptTemplate", {
-        ...promptTemplate,
-        stopStrings: ["<beta-stop>"],
-      }),
-    ]);
-
-    expect(globalConfigSchematics.access(loadConfig, "llm.load.promptTemplate")).toEqual(
-      promptTemplate,
-    );
-  });
 
   it("rejects undefined as a load-time prompt template stored value", () => {
     expect(llmLoadSchematics.getSchemaForKey("promptTemplate").safeParse(undefined).success).toBe(

--- a/packages/lms-kv-config/src/schema.test.ts
+++ b/packages/lms-kv-config/src/schema.test.ts
@@ -78,7 +78,6 @@ describe("llmLoadModelConfig conversion", () => {
       jinjaPromptTemplate: {
         template: "{% for message in messages %}{{ message.content }}{% endfor %}",
       },
-      stopStrings: ["<|end|>"],
     };
     const loadConfig = llmLoadModelConfigToKVConfig({
       promptTemplate,
@@ -363,17 +362,35 @@ describe("llmLoadModelConfig conversion", () => {
 });
 
 describe("globalConfigSchematics", () => {
-  it("accepts load-time Jinja prompt template with stop strings", () => {
+  it("accepts load-time Jinja prompt template", () => {
     const promptTemplate = {
       type: "jinja" as const,
       jinjaPromptTemplate: {
         template: "{% for message in messages %}{{ message.content }}{% endfor %}",
       },
-      stopStrings: ["<|end|>"],
     };
     const loadConfig = llmLoadSchematics.buildPartialConfig({
       promptTemplate,
     });
+
+    expect(globalConfigSchematics.access(loadConfig, "llm.load.promptTemplate")).toEqual(
+      promptTemplate,
+    );
+  });
+
+  it("ignores beta load-time prompt template stop strings", () => {
+    const promptTemplate = {
+      type: "jinja" as const,
+      jinjaPromptTemplate: {
+        template: "{% for message in messages %}{{ message.content }}{% endfor %}",
+      },
+    };
+    const loadConfig = makeKVConfigFromFields([
+      kvConfigField("llm.load.promptTemplate", {
+        ...promptTemplate,
+        stopStrings: ["<beta-stop>"],
+      }),
+    ]);
 
     expect(globalConfigSchematics.access(loadConfig, "llm.load.promptTemplate")).toEqual(
       promptTemplate,
@@ -433,7 +450,6 @@ describe("globalConfigSchematics", () => {
       jinjaPromptTemplate: {
         template: "{% for message in messages %}{{ message.content }}{% endfor %}",
       },
-      stopStrings: ["<|end|>"],
     };
     const schematics = new KVConfigSchematicsBuilder(kvValueTypesLibrary)
       .field("promptTemplate", "llmLoadPromptTemplate", {}, promptTemplate)

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -48,7 +48,6 @@ export const defaultLlmLoadPromptTemplate: LLMLoadPromptTemplate = {
       "{% endfor %}" +
       "{% if add_generation_prompt %}{{ 'AI: ' }}{% endif %}",
   },
-  stopStrings: [],
 };
 
 // ---------------------------

--- a/packages/lms-kv-config/src/valueTypes.ts
+++ b/packages/lms-kv-config/src/valueTypes.ts
@@ -562,11 +562,7 @@ export const kvValueTypesLibrary = baseKVValueTypesLibraryBuilder
       return llmLoadPromptTemplateSchema;
     },
     effectiveEquals: (a, b) => {
-      return (
-        a.jinjaPromptTemplate.template === b.jinjaPromptTemplate.template &&
-        a.stopStrings.length === b.stopStrings.length &&
-        a.stopStrings.every((stopString, index) => stopString === b.stopStrings[index])
-      );
+      return a.jinjaPromptTemplate.template === b.jinjaPromptTemplate.template;
     },
     stringify: (value, _typeParam, { t, desiredLength }) => {
       const lead =

--- a/packages/lms-shared-types/src/llm/LLMLoadPromptTemplate.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadPromptTemplate.ts
@@ -5,11 +5,9 @@ import { llmJinjaPromptTemplateSchema, type LLMJinjaPromptTemplate } from "./LLM
 export interface LLMLoadPromptTemplate {
   type: "jinja";
   jinjaPromptTemplate: LLMJinjaPromptTemplate;
-  stopStrings: Array<string>;
 }
 
 export const llmLoadPromptTemplateSchema = z.object({
   type: z.literal("jinja"),
   jinjaPromptTemplate: llmJinjaPromptTemplateSchema,
-  stopStrings: z.array(z.string()),
 }) as z.Schema<LLMLoadPromptTemplate>;


### PR DESCRIPTION
Removes stop strings from the load-time prompt template while keeping prediction-time stop strings unchanged.