### PR TITLE
Add raw completion SDK channel

### DIFF
--- a/packages/lms-client/src/llm/LLMDynamicHandle.rawCompletionChannel.test.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.rawCompletionChannel.test.ts
@@ -1,0 +1,126 @@
+import { SimpleLogger, Validator } from "@lmstudio/lms-common";
+import { type LLMPort } from "@lmstudio/lms-external-backend-interfaces";
+import { collapseKVStack, globalConfigSchematics } from "@lmstudio/lms-kv-config";
+import { type KVConfigStack, type LLMInstanceInfo } from "@lmstudio/lms-shared-types";
+import { Chat } from "../Chat.js";
+import { LLMDynamicHandle } from "./LLMDynamicHandle.js";
+
+interface CapturedChannelCreation {
+  endpointName: string;
+  creationParameter: unknown;
+}
+
+function createInstanceInfo(): LLMInstanceInfo {
+  return {
+    type: "llm",
+    modelKey: "test/model",
+    format: "gguf",
+    displayName: "Test Model",
+    publisher: "test",
+    path: "/test/model.gguf",
+    sizeBytes: 0,
+    indexedModelIdentifier: "test/model",
+    deviceIdentifier: null,
+    identifier: "test-instance",
+    instanceReference: "test-instance",
+    ttlMs: null,
+    lastUsedTime: null,
+    vision: false,
+    trainedForToolUse: false,
+    maxContextLength: 4096,
+    contextLength: 4096,
+  };
+}
+
+function createSilentLogger(): SimpleLogger {
+  return new SimpleLogger("rawCompletionChannelTest", {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  });
+}
+
+function createHandleHarness() {
+  const capturedChannelCreations = new Array<CapturedChannelCreation>();
+  const port = {
+    createChannel: (
+      endpointName: string,
+      creationParameter: unknown,
+      onMessage: (message: unknown) => void,
+    ) => {
+      capturedChannelCreations.push({ endpointName, creationParameter });
+      queueMicrotask(() => {
+        if (endpointName !== "predict" && endpointName !== "completeRawText") {
+          throw new Error(`Unexpected channel endpoint: ${endpointName}`);
+        }
+        onMessage({
+          type: "success",
+          stats: { stopReason: "eosFound" },
+          modelInfo: createInstanceInfo(),
+          loadModelConfig: { fields: [] },
+          predictionConfig: { fields: [] },
+        });
+      });
+      return {
+        onError: {
+          subscribeOnce: () => {},
+        },
+        send: () => {},
+      };
+    },
+  } as unknown as LLMPort;
+
+  return {
+    handle: new LLMDynamicHandle(
+      port,
+      { type: "instanceReference", instanceReference: "test-instance" },
+      new Validator({ attachStack: false }),
+      createSilentLogger(),
+    ),
+    capturedChannelCreations,
+  };
+}
+
+function getPredictionConfigStack(creationParameter: unknown): KVConfigStack {
+  if (
+    typeof creationParameter !== "object" ||
+    creationParameter === null ||
+    !("predictionConfigStack" in creationParameter)
+  ) {
+    throw new Error("Expected channel creation parameter to include predictionConfigStack.");
+  }
+
+  return (creationParameter as { predictionConfigStack: KVConfigStack }).predictionConfigStack;
+}
+
+describe("LLMDynamicHandle raw completion channel", () => {
+  test("complete opens completeRawText with rawPrompt", async () => {
+    const harness = createHandleHarness();
+
+    await harness.handle.complete("raw prompt");
+
+    const capturedCreation = harness.capturedChannelCreations[0];
+    expect(capturedCreation?.endpointName).toBe("completeRawText");
+    expect(capturedCreation?.creationParameter).toMatchObject({
+      rawPrompt: "raw prompt",
+      modelSpecifier: { type: "instanceReference", instanceReference: "test-instance" },
+    });
+    const predictionConfigStack = getPredictionConfigStack(capturedCreation?.creationParameter);
+    expect(predictionConfigStack.layers.map(layer => layer.layerName)).toEqual(["apiOverride"]);
+    expect(
+      globalConfigSchematics.access(
+        collapseKVStack(predictionConfigStack),
+        "llm.prediction.stopStrings",
+      ),
+    ).toEqual([]);
+  });
+
+  test("respond remains on predict", async () => {
+    const harness = createHandleHarness();
+
+    await harness.handle.respond(Chat.from([{ role: "user", content: "hello" }]));
+
+    expect(harness.capturedChannelCreations[0]?.endpointName).toBe("predict");
+  });
+});

--- a/packages/lms-client/src/llm/LLMDynamicHandle.rawCompletionChannel.test.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.rawCompletionChannel.test.ts
@@ -116,6 +116,18 @@ describe("LLMDynamicHandle raw completion channel", () => {
     ).toEqual([]);
   });
 
+  test.each([
+    ["rawTools", { rawTools: { type: "none" } }],
+    ["toolChoice", { toolChoice: { type: "generic", mode: "none" } }],
+  ] as const)("complete rejects explicit %s config before opening a channel", (_label, opts) => {
+    const harness = createHandleHarness();
+
+    expect(() => harness.handle.complete("raw prompt", opts)).toThrow(
+      "Tools are not supported in model.complete().",
+    );
+    expect(harness.capturedChannelCreations).toEqual([]);
+  });
+
   test("respond remains on predict", async () => {
     const harness = createHandleHarness();
 

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -5,7 +5,6 @@ import {
   makePrettyError,
   safeCallCallback,
   SimpleLogger,
-  text,
   type Validator,
 } from "@lmstudio/lms-common";
 import { type LLMPort } from "@lmstudio/lms-external-backend-interfaces";
@@ -16,7 +15,6 @@ import {
   kvConfigToLLMPredictionConfig,
   llmPredictionConfigToKVConfig,
   llmSharedLoadConfigSchematics,
-  llmSharedPredictionConfigSchematics,
 } from "@lmstudio/lms-kv-config";
 import {
   type ChatHistoryData,
@@ -401,10 +399,6 @@ function splitActOpts<TStructuredOutputType>(
   ];
 }
 
-const noFormattingTemplate = text`
-  {% for message in messages %}{{ message['content'] }}{% endfor %}
-`;
-
 /**
  * This represents a set of requirements for a model. It is not tied to a specific model, but rather
  * to a set of requirements that a model must satisfy.
@@ -601,6 +595,77 @@ export class LLMDynamicHandle extends DynamicHandle<
     channel.onError.subscribeOnce(onError);
   }
 
+  /** @internal */
+  private internalCompleteRawText(
+    rawPrompt: string,
+    predictionConfigStack: KVConfigStack,
+    cancelEvent: BufferedEvent<void>,
+    extraOpts: LLMPredictionExtraOpts,
+    onFragment: (fragment: LLMPredictionFragment) => void,
+    onFinished: (
+      stats: LLMPredictionStats,
+      modelInfo: LLMInstanceInfo,
+      loadModelConfig: KVConfig,
+      predictionConfig: KVConfig,
+    ) => void,
+    onError: (error: Error) => void,
+  ) {
+    let finished = false;
+    let firstTokenTriggered = false;
+    const channel = this.port.createChannel(
+      "completeRawText",
+      {
+        modelSpecifier: this.specifier,
+        rawPrompt,
+        predictionConfigStack,
+        fuzzyPresetIdentifier: extraOpts.preset,
+        ignoreServerSessionConfig: this.internalIgnoreServerSessionConfig,
+      },
+      message => {
+        switch (message.type) {
+          case "fragment": {
+            if (!firstTokenTriggered) {
+              firstTokenTriggered = true;
+              safeCallCallback(this.logger, "onFirstToken", extraOpts.onFirstToken, []);
+            }
+            safeCallCallback(this.logger, "onFragment", extraOpts.onPredictionFragment, [
+              message.fragment,
+            ]);
+            onFragment(message.fragment);
+            break;
+          }
+          case "promptProcessingProgress": {
+            safeCallCallback(
+              this.logger,
+              "onPromptProcessingProgress",
+              extraOpts.onPromptProcessingProgress,
+              [message.progress, message.details],
+            );
+            break;
+          }
+          case "success": {
+            finished = true;
+            onFinished(
+              message.stats,
+              message.modelInfo,
+              message.loadModelConfig,
+              message.predictionConfig,
+            );
+            break;
+          }
+        }
+      },
+      { stack: getCurrentStack(2) },
+    );
+    cancelEvent.subscribeOnce(() => {
+      if (finished) {
+        return;
+      }
+      channel.send({ type: "cancel" });
+    });
+    channel.onError.subscribeOnce(onError);
+  }
+
   private predictionConfigInputToKVConfig(config: LLMPredictionConfigInput): KVConfig {
     let structuredField: undefined | LLMStructuredPredictionSetting = undefined;
     if (typeof (config.structured as any)?.parse === "function") {
@@ -712,8 +777,8 @@ export class LLMDynamicHandle extends DynamicHandle<
       !zodSchemaParseResult.success ? null : this.createZodParser(zodSchemaParseResult.data),
     );
 
-    this.internalPredict(
-      this.resolveCompletionContext(prompt),
+    this.internalCompleteRawText(
+      prompt,
       {
         layers: [
           ...this.internalKVConfigStack.layers,
@@ -726,18 +791,6 @@ export class LLMDynamicHandle extends DynamicHandle<
               ...config,
             }),
           },
-          {
-            layerName: "completeModeFormatting",
-            config: llmSharedPredictionConfigSchematics.buildPartialConfig({
-              promptTemplate: {
-                type: "jinja",
-                jinjaPromptTemplate: {
-                  template: noFormattingTemplate,
-                },
-                stopStrings: [],
-              },
-            }),
-          },
         ],
       },
       cancelEvent,
@@ -748,17 +801,6 @@ export class LLMDynamicHandle extends DynamicHandle<
       error => failed(error),
     );
     return ongoingPrediction;
-  }
-
-  private resolveCompletionContext(contextInput: string): ChatHistoryData {
-    return {
-      messages: [
-        {
-          role: "user",
-          content: [{ type: "text", text: contextInput }],
-        },
-      ],
-    };
   }
 
   /**

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -233,6 +233,20 @@ function splitPredictionOpts<TStructuredOutputType>(
   ];
 }
 
+function validateRawCompletionConfigDoesNotRequestTools(
+  config: LLMPredictionConfigInput,
+  stack: string,
+): void {
+  if (config.rawTools === undefined && config.toolChoice === undefined) {
+    return;
+  }
+
+  throw makePrettyError(
+    "Tools are not supported in model.complete(). Use model.respond() or model.act() for tool use.",
+    stack,
+  );
+}
+
 /**
  * Options for {@link LLMDynamicHandle#respond}.
  *
@@ -754,6 +768,7 @@ export class LLMDynamicHandle extends DynamicHandle<
       stack,
     );
     const [config, extraOpts] = splitPredictionOpts(opts);
+    validateRawCompletionConfigDoesNotRequestTools(config, stack);
     const [cancelEvent, emitCancelEvent] = BufferedEvent.create<void>();
 
     if (extraOpts.signal !== undefined) {

--- a/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
@@ -102,6 +102,41 @@ export function createLlmBackendInterface() {
           }),
         ]),
       })
+      .addChannelEndpoint("completeRawText", {
+        creationParameter: z.object({
+          modelSpecifier: modelSpecifierSchema,
+          rawPrompt: z.string(),
+          predictionConfigStack: kvConfigStackSchema,
+          /**
+           * Which preset to use. Supports limited fuzzy matching.
+           */
+          fuzzyPresetIdentifier: z.string().optional(),
+          ignoreServerSessionConfig: z.boolean().optional(),
+        }),
+        toClientPacket: z.discriminatedUnion("type", [
+          z.object({
+            type: z.literal("fragment"),
+            fragment: llmPredictionFragmentSchema,
+          }),
+          z.object({
+            type: z.literal("promptProcessingProgress"),
+            progress: z.number(),
+            details: promptProcessingDetailsSchema,
+          }),
+          z.object({
+            type: z.literal("success"),
+            stats: llmPredictionStatsSchema,
+            modelInfo: llmInstanceInfoSchema,
+            loadModelConfig: kvConfigSchema,
+            predictionConfig: kvConfigSchema,
+          }),
+        ]),
+        toServerPacket: z.discriminatedUnion("type", [
+          z.object({
+            type: z.literal("cancel"),
+          }),
+        ]),
+      })
       .addRpcEndpoint("applyPromptTemplate", {
         parameter: z.object({
           specifier: modelSpecifierSchema,


### PR DESCRIPTION
Adds a dedicated raw completion backend channel, routes SDK `model.complete(...)` through it, and adds focused channel-selection tests.