### PR TITLE
Fix lms-isomorphic browser exports

### DIFF
--- a/packages/lms-isomorphic/package.json
+++ b/packages/lms-isomorphic/package.json
@@ -21,6 +21,12 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "browser": {
+        "types": "./dist/types/browser.d.ts",
+        "require": "./dist/cjs/browser.js",
+        "import": "./dist/esm/browser.js",
+        "default": "./dist/esm/browser.js"
+      },
       "types": "./dist/types/index.d.ts",
       "require": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",


### PR DESCRIPTION
## Summary
- add a browser conditional export for @lmstudio/lms-isomorphic
- keep Node import/require paths unchanged

## Testing
- npm run build --workspace=@lmstudio/lms-isomorphic