### PR TITLE
Signal explicit freshness

### DIFF
--- a/packages/lms-common/src/LazySignal.test.ts
+++ b/packages/lms-common/src/LazySignal.test.ts
@@ -323,6 +323,48 @@ describe("LazySignal", () => {
     await expect(pullPromise).resolves.toBe("first-recovered:second-fresh");
   });
 
+  it("should not derive from a stale source after an earlier successful derivation", () => {
+    let emitFirstUpstream: (value: string) => void = () => {};
+    let failFirstUpstream: (error: Error) => void = () => {};
+    const firstSourceSignal = LazySignal.create(
+      "first-cached",
+      (setDownstream, errorListener) => {
+        emitFirstUpstream = setDownstream;
+        failFirstUpstream = errorListener;
+        return () => {};
+      },
+    );
+    let emitSecondUpstream: (value: string) => void = () => {};
+    const secondSourceSignal = LazySignal.create("second-cached", setDownstream => {
+      emitSecondUpstream = setDownstream;
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [firstSourceSignal, secondSourceSignal],
+      (firstValue, secondValue) => `${firstValue}:${secondValue}`,
+    );
+    const listener = jest.fn();
+    const unsubscribe = derivedSignal.subscribe(listener);
+
+    emitFirstUpstream("first-fresh");
+    emitSecondUpstream("second-fresh");
+    expect(derivedSignal.get()).toBe("first-fresh:second-fresh");
+    listener.mockClear();
+
+    failFirstUpstream(new Error("upstream failed"));
+    expect(firstSourceSignal.recoverFromError()).toBe(true);
+    emitSecondUpstream("second-new");
+
+    expect(firstSourceSignal.isStale()).toBe(true);
+    expect(listener).not.toHaveBeenCalled();
+    expect(derivedSignal.get()).toBe("first-fresh:second-fresh");
+
+    emitFirstUpstream("first-recovered");
+    expect(listener).toHaveBeenCalledWith("first-recovered:second-new");
+    expect(derivedSignal.get()).toBe("first-recovered:second-new");
+    unsubscribe();
+  });
+
   it("should capture a synchronous upstream emission during subscription", async () => {
     const sourceSignal = LazySignal.create("cached", setDownstream => {
       setDownstream("synchronous");

--- a/packages/lms-common/src/LazySignal.test.ts
+++ b/packages/lms-common/src/LazySignal.test.ts
@@ -202,6 +202,41 @@ describe("LazySignal", () => {
     unsubscribeReentrantUpdate();
   });
 
+  it("should finish stale when a source errors reentrantly during a fresh update", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    let failUpstream: (error: Error) => void = () => {};
+    const sourceSignal = LazySignal.create("cached", (setDownstream, errorListener) => {
+      emitUpstream = setDownstream;
+      failUpstream = errorListener;
+      return () => {};
+    });
+    const unsubscribeReentrantError = sourceSignal.subscribe(value => {
+      if (value === "updated") {
+        failUpstream(new Error("failed during delivery"));
+      }
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `derived:${sourceValue}`,
+    );
+    const unsubscribe = derivedSignal.subscribe(() => {});
+
+    emitUpstream("initial");
+    emitUpstream("updated");
+
+    expect(sourceSignal.isStale()).toBe(true);
+    expect(derivedSignal.isStale()).toBe(true);
+    expect(derivedSignal.get()).toBe("derived:updated");
+
+    const pullPromise = derivedSignal.pull();
+    expect(sourceSignal.recoverFromError()).toBe(true);
+    emitUpstream("recovered");
+    await expect(pullPromise).resolves.toBe("derived:recovered");
+
+    unsubscribe();
+    unsubscribeReentrantError();
+  });
+
   it("should wait for a same-value refresh from a stale source", async () => {
     let emitUpstream: (value: string) => void = () => {};
     const sourceSignal = LazySignal.create("unchanged", setDownstream => {
@@ -284,14 +319,11 @@ describe("LazySignal", () => {
   it("should continue waiting when a stale source errors before its first refresh and recovers", async () => {
     let emitFirstUpstream: (value: string) => void = () => {};
     let failFirstUpstream: (error: Error) => void = () => {};
-    const firstSourceSignal = LazySignal.create(
-      "first-cached",
-      (setDownstream, errorListener) => {
-        emitFirstUpstream = setDownstream;
-        failFirstUpstream = errorListener;
-        return () => {};
-      },
-    );
+    const firstSourceSignal = LazySignal.create("first-cached", (setDownstream, errorListener) => {
+      emitFirstUpstream = setDownstream;
+      failFirstUpstream = errorListener;
+      return () => {};
+    });
     let emitSecondUpstream: (value: string) => void = () => {};
     const secondSourceSignal = LazySignal.create("second-cached", setDownstream => {
       emitSecondUpstream = setDownstream;
@@ -321,14 +353,11 @@ describe("LazySignal", () => {
   it("should wait for a recovered source to refresh again if it errors while other sources are pending", async () => {
     let emitFirstUpstream: (value: string) => void = () => {};
     let failFirstUpstream: (error: Error) => void = () => {};
-    const firstSourceSignal = LazySignal.create(
-      "first-cached",
-      (setDownstream, errorListener) => {
-        emitFirstUpstream = setDownstream;
-        failFirstUpstream = errorListener;
-        return () => {};
-      },
-    );
+    const firstSourceSignal = LazySignal.create("first-cached", (setDownstream, errorListener) => {
+      emitFirstUpstream = setDownstream;
+      failFirstUpstream = errorListener;
+      return () => {};
+    });
     let emitSecondUpstream: (value: string) => void = () => {};
     const secondSourceSignal = LazySignal.create("second-cached", setDownstream => {
       emitSecondUpstream = setDownstream;
@@ -361,14 +390,11 @@ describe("LazySignal", () => {
   it("should not derive from a stale source after an earlier successful derivation", () => {
     let emitFirstUpstream: (value: string) => void = () => {};
     let failFirstUpstream: (error: Error) => void = () => {};
-    const firstSourceSignal = LazySignal.create(
-      "first-cached",
-      (setDownstream, errorListener) => {
-        emitFirstUpstream = setDownstream;
-        failFirstUpstream = errorListener;
-        return () => {};
-      },
-    );
+    const firstSourceSignal = LazySignal.create("first-cached", (setDownstream, errorListener) => {
+      emitFirstUpstream = setDownstream;
+      failFirstUpstream = errorListener;
+      return () => {};
+    });
     let emitSecondUpstream: (value: string) => void = () => {};
     const secondSourceSignal = LazySignal.create("second-cached", setDownstream => {
       emitSecondUpstream = setDownstream;

--- a/packages/lms-common/src/LazySignal.test.ts
+++ b/packages/lms-common/src/LazySignal.test.ts
@@ -365,6 +365,41 @@ describe("LazySignal", () => {
     unsubscribe();
   });
 
+  it("should become stale and make pull wait when a source errors after deriving", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    let failUpstream: (error: Error) => void = () => {};
+    const sourceSignal = LazySignal.create("cached", (setDownstream, errorListener) => {
+      emitUpstream = setDownstream;
+      failUpstream = errorListener;
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `derived:${sourceValue}`,
+    );
+    const unsubscribe = derivedSignal.subscribe(() => {});
+
+    emitUpstream("fresh");
+    expect(derivedSignal.isStale()).toBe(false);
+
+    failUpstream(new Error("upstream failed"));
+    expect(derivedSignal.isStale()).toBe(true);
+
+    const pullPromise = derivedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    expect(sourceSignal.recoverFromError()).toBe(true);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(pullResolved).toBe(false);
+
+    emitUpstream("fresh");
+    await expect(pullPromise).resolves.toBe("derived:fresh");
+    expect(derivedSignal.isStale()).toBe(false);
+    unsubscribe();
+  });
+
   it("should capture a synchronous upstream emission during subscription", async () => {
     const sourceSignal = LazySignal.create("cached", setDownstream => {
       setDownstream("synchronous");

--- a/packages/lms-common/src/LazySignal.test.ts
+++ b/packages/lms-common/src/LazySignal.test.ts
@@ -85,6 +85,223 @@ describe("LazySignal", () => {
     await expect(promise).resolves.toBe(data);
   });
 
+  it("should allow waiting for fresh data to be cancelled", () => {
+    let emitUpstream: (value: string) => void = () => {};
+    const unsubscribeUpstream = jest.fn();
+    const lazySignal = LazySignal.create("cached", setDownstream => {
+      emitUpstream = setDownstream;
+      return unsubscribeUpstream;
+    });
+    const callback = jest.fn();
+
+    const cancel = lazySignal.runOnNextFreshData(callback);
+    cancel();
+    emitUpstream("fresh");
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(unsubscribeUpstream).toHaveBeenCalledTimes(1);
+  });
+
+  it("should clean up after fresh data is emitted synchronously during subscription", () => {
+    const unsubscribeUpstream = jest.fn();
+    const lazySignal = LazySignal.create("cached", setDownstream => {
+      setDownstream("fresh");
+      return unsubscribeUpstream;
+    });
+    const callback = jest.fn();
+
+    lazySignal.runOnNextFreshData(callback);
+
+    expect(callback).toHaveBeenCalledWith("fresh");
+    expect(unsubscribeUpstream).toHaveBeenCalledTimes(1);
+    expect(lazySignal.isStale()).toBe(true);
+  });
+
+  it("should not let a derived signal treat a stale source value as fresh", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    const sourceSignal = LazySignal.create("cached", setDownstream => {
+      emitUpstream = setDownstream;
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `derived:${sourceValue}`,
+    );
+
+    const pullPromise = derivedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(sourceSignal.isStale()).toBe(true);
+    expect(pullResolved).toBe(false);
+
+    emitUpstream("fresh");
+    await expect(pullPromise).resolves.toBe("derived:fresh");
+  });
+
+  it("should pull fresh data through a nested derive chain", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    const sourceSignal = LazySignal.createWithoutInitialValue<string>(setDownstream => {
+      emitUpstream = setDownstream;
+      return () => {};
+    });
+    const firstDerivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `first:${sourceValue}`,
+    );
+    const secondDerivedSignal = LazySignal.deriveFrom(
+      [firstDerivedSignal],
+      firstDerivedValue => `second:${firstDerivedValue}`,
+    );
+
+    const initialPullPromise = secondDerivedSignal.pull();
+    emitUpstream("initial");
+    await expect(initialPullPromise).resolves.toBe("second:first:initial");
+
+    const refreshedPullPromise = secondDerivedSignal.pull();
+    emitUpstream("updated");
+
+    await expect(refreshedPullPromise).resolves.toBe("second:first:updated");
+  });
+
+  it("should wait for a same-value refresh from a stale source", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    const sourceSignal = LazySignal.create("unchanged", setDownstream => {
+      emitUpstream = setDownstream;
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `derived:${sourceValue}`,
+    );
+
+    const pullPromise = derivedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(pullResolved).toBe(false);
+
+    emitUpstream("unchanged");
+    await expect(pullPromise).resolves.toBe("derived:unchanged");
+  });
+
+  it("should wait until every source has fresh data", async () => {
+    const eagerSourceSignal = Signal.createReadonly("eager");
+    let emitLazyUpstream: (value: string) => void = () => {};
+    const lazySourceSignal = LazySignal.create("cached", setDownstream => {
+      emitLazyUpstream = setDownstream;
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [eagerSourceSignal, lazySourceSignal],
+      (eagerValue, lazyValue) => `${eagerValue}:${lazyValue}`,
+    );
+
+    const pullPromise = derivedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(pullResolved).toBe(false);
+
+    emitLazyUpstream("fresh");
+    await expect(pullPromise).resolves.toBe("eager:fresh");
+  });
+
+  it("should capture a synchronous upstream emission during subscription", async () => {
+    const sourceSignal = LazySignal.create("cached", setDownstream => {
+      setDownstream("synchronous");
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `derived:${sourceValue}`,
+    );
+
+    await expect(derivedSignal.pull()).resolves.toBe("derived:synchronous");
+  });
+
+  it("should capture the last of several synchronous subscription emissions", async () => {
+    const sourceSignal = LazySignal.create("cached", setDownstream => {
+      setDownstream("first");
+      setDownstream("second");
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `derived:${sourceValue}`,
+    );
+
+    await expect(derivedSignal.pull()).resolves.toBe("derived:second");
+  });
+
+  it("should release stale source subscriptions when the derived signal is unsubscribed", () => {
+    let activeUpstreamSubscriptions = 0;
+    const sourceSignal = LazySignal.create("cached", () => {
+      activeUpstreamSubscriptions++;
+      return () => {
+        activeUpstreamSubscriptions--;
+      };
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `derived:${sourceValue}`,
+    );
+
+    const unsubscribe = derivedSignal.subscribe(() => {});
+    expect(activeUpstreamSubscriptions).toBe(1);
+
+    unsubscribe();
+    expect(activeUpstreamSubscriptions).toBe(0);
+  });
+
+  it("should propagate eager source updates synchronously", () => {
+    const [sourceSignal, setSourceSignal] = Signal.create("initial");
+    const derivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `derived:${sourceValue}`,
+    );
+    const listener = jest.fn();
+    const unsubscribe = derivedSignal.subscribe(listener);
+
+    setSourceSignal("updated");
+
+    expect(listener).toHaveBeenCalledWith("derived:updated");
+    expect(derivedSignal.get()).toBe("derived:updated");
+    unsubscribe();
+  });
+
+  it("should wait for an unavailable source to become available", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    const sourceSignal = LazySignal.createWithoutInitialValue<string>(setDownstream => {
+      emitUpstream = setDownstream;
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `derived:${sourceValue}`,
+    );
+
+    const pullPromise = derivedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await Promise.resolve();
+    expect(pullResolved).toBe(false);
+
+    emitUpstream("available");
+    await expect(pullPromise).resolves.toBe("derived:available");
+  });
+
   it("should preserve tags from the upstream", () => {
     const data = "test";
     let callback: (data: string, tags: Array<WriteTag>) => void = () => {};
@@ -380,6 +597,26 @@ describe("LazySignal", () => {
   });
 });
 
+describe("asyncDeriveFrom", () => {
+  it("should wait for fresh source data before invoking the deriver", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    const sourceSignal = LazySignal.create("cached", setDownstream => {
+      emitUpstream = setDownstream;
+      return () => {};
+    });
+    const deriver = jest.fn(async (sourceValue: string) => `derived:${sourceValue}`);
+    const derivedSignal = LazySignal.asyncDeriveFrom("eager", [sourceSignal], deriver);
+
+    const pullPromise = derivedSignal.pull();
+    await Promise.resolve();
+    expect(deriver).not.toHaveBeenCalled();
+
+    emitUpstream("fresh");
+    await expect(pullPromise).resolves.toBe("derived:fresh");
+    expect(deriver).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("blockingAsyncDeriveFromWithThrottling", () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -413,6 +650,27 @@ describe("blockingAsyncDeriveFromWithThrottling", () => {
 
     return { deriver, invocations };
   }
+
+  it("should wait for fresh source data before invoking the deriver", () => {
+    let emitUpstream: (value: string) => void = () => {};
+    const sourceSignal = LazySignal.create("cached", setDownstream => {
+      emitUpstream = setDownstream;
+      return () => {};
+    });
+    const { deriver, invocations } = createControllableDeriver<string>();
+    const derivedSignal = LazySignal.blockingAsyncDeriveFromWithThrottling(
+      0,
+      [sourceSignal],
+      deriver,
+    );
+
+    derivedSignal.subscribe(() => {});
+    expect(invocations).toHaveLength(0);
+
+    emitUpstream("fresh");
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0].args).toEqual(["fresh"]);
+  });
 
   it("should run derives serially, not concurrently", async () => {
     const [source, setSource] = Signal.create("A");
@@ -651,11 +909,7 @@ describe("blockingAsyncDeriveFromWithThrottling", () => {
       return deriver(...args);
     };
 
-    const derived = LazySignal.blockingAsyncDeriveFromWithThrottling(
-      0,
-      [source],
-      throwOnceDeriver,
-    );
+    const derived = LazySignal.blockingAsyncDeriveFromWithThrottling(0, [source], throwOnceDeriver);
     derived.subscribe(() => {});
 
     // A's derive throws synchronously — should not crash or freeze

--- a/packages/lms-common/src/LazySignal.test.ts
+++ b/packages/lms-common/src/LazySignal.test.ts
@@ -216,6 +216,113 @@ describe("LazySignal", () => {
     await expect(pullPromise).resolves.toBe("eager:fresh");
   });
 
+  it("should wait for multiple stale sources that refresh out of order", async () => {
+    let emitFirstUpstream: (value: string) => void = () => {};
+    const firstSourceSignal = LazySignal.create("first-cached", setDownstream => {
+      emitFirstUpstream = setDownstream;
+      return () => {};
+    });
+    let emitSecondUpstream: (value: string) => void = () => {};
+    const secondSourceSignal = LazySignal.create("second-cached", setDownstream => {
+      emitSecondUpstream = setDownstream;
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [firstSourceSignal, secondSourceSignal],
+      (firstValue, secondValue) => `${firstValue}:${secondValue}`,
+    );
+
+    const pullPromise = derivedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+
+    emitSecondUpstream("second-fresh");
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(pullResolved).toBe(false);
+
+    emitFirstUpstream("first-fresh");
+    await expect(pullPromise).resolves.toBe("first-fresh:second-fresh");
+  });
+
+  it("should continue waiting when a stale source errors before its first refresh and recovers", async () => {
+    let emitFirstUpstream: (value: string) => void = () => {};
+    let failFirstUpstream: (error: Error) => void = () => {};
+    const firstSourceSignal = LazySignal.create(
+      "first-cached",
+      (setDownstream, errorListener) => {
+        emitFirstUpstream = setDownstream;
+        failFirstUpstream = errorListener;
+        return () => {};
+      },
+    );
+    let emitSecondUpstream: (value: string) => void = () => {};
+    const secondSourceSignal = LazySignal.create("second-cached", setDownstream => {
+      emitSecondUpstream = setDownstream;
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [firstSourceSignal, secondSourceSignal],
+      (firstValue, secondValue) => `${firstValue}:${secondValue}`,
+    );
+
+    const pullPromise = derivedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+
+    failFirstUpstream(new Error("upstream failed"));
+    expect(firstSourceSignal.recoverFromError()).toBe(true);
+    emitSecondUpstream("second-fresh");
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(pullResolved).toBe(false);
+
+    emitFirstUpstream("first-recovered");
+    await expect(pullPromise).resolves.toBe("first-recovered:second-fresh");
+  });
+
+  it("should wait for a recovered source to refresh again if it errors while other sources are pending", async () => {
+    let emitFirstUpstream: (value: string) => void = () => {};
+    let failFirstUpstream: (error: Error) => void = () => {};
+    const firstSourceSignal = LazySignal.create(
+      "first-cached",
+      (setDownstream, errorListener) => {
+        emitFirstUpstream = setDownstream;
+        failFirstUpstream = errorListener;
+        return () => {};
+      },
+    );
+    let emitSecondUpstream: (value: string) => void = () => {};
+    const secondSourceSignal = LazySignal.create("second-cached", setDownstream => {
+      emitSecondUpstream = setDownstream;
+      return () => {};
+    });
+    const derivedSignal = LazySignal.deriveFrom(
+      [firstSourceSignal, secondSourceSignal],
+      (firstValue, secondValue) => `${firstValue}:${secondValue}`,
+    );
+
+    const pullPromise = derivedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+
+    emitFirstUpstream("first-fresh");
+    failFirstUpstream(new Error("upstream failed"));
+    expect(firstSourceSignal.recoverFromError()).toBe(true);
+    emitSecondUpstream("second-fresh");
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(firstSourceSignal.isStale()).toBe(true);
+    expect(pullResolved).toBe(false);
+
+    emitFirstUpstream("first-recovered");
+    await expect(pullPromise).resolves.toBe("first-recovered:second-fresh");
+  });
+
   it("should capture a synchronous upstream emission during subscription", async () => {
     const sourceSignal = LazySignal.create("cached", setDownstream => {
       setDownstream("synchronous");

--- a/packages/lms-common/src/LazySignal.test.ts
+++ b/packages/lms-common/src/LazySignal.test.ts
@@ -1,5 +1,6 @@
 import { LazySignal } from "./LazySignal.js";
-import { type WriteTag } from "./makeSetter.js";
+import { type Setter, type WriteTag } from "./makeSetter.js";
+import { OWLSignal } from "./OWLSignal.js";
 import { Signal } from "./Signal.js";
 
 describe("LazySignal", () => {
@@ -165,6 +166,40 @@ describe("LazySignal", () => {
     emitUpstream("updated");
 
     await expect(refreshedPullPromise).resolves.toBe("second:first:updated");
+  });
+
+  it("should derive once from the final value of a reentrant OWLSignal refresh", () => {
+    const initialValue = { count: 0 };
+    let emitUpstream!: Setter<typeof initialValue>;
+    const [sourceSignal, setSourceSignal] = OWLSignal.create(
+      initialValue,
+      setDownstream => {
+        emitUpstream = setDownstream;
+        return () => {};
+      },
+      () => true,
+    );
+    const unsubscribeReentrantUpdate = sourceSignal.subscribe(value => {
+      if (value.count === 1) {
+        emitUpstream({ count: 10 });
+      }
+    });
+    const derivedSignal = LazySignal.deriveFrom([sourceSignal], value => value.count);
+    const listener = jest.fn();
+    const unsubscribe = derivedSignal.subscribe(listener);
+
+    setSourceSignal.withProducer(draft => {
+      draft.count += 1;
+    });
+
+    expect(sourceSignal.isStale()).toBe(false);
+    expect(sourceSignal.get()).toEqual({ count: 11 });
+    expect(derivedSignal.isStale()).toBe(false);
+    expect(derivedSignal.get()).toBe(11);
+    expect(listener.mock.calls).toEqual([[11]]);
+
+    unsubscribe();
+    unsubscribeReentrantUpdate();
   });
 
   it("should wait for a same-value refresh from a stale source", async () => {

--- a/packages/lms-common/src/LazySignal.test.ts
+++ b/packages/lms-common/src/LazySignal.test.ts
@@ -400,6 +400,40 @@ describe("LazySignal", () => {
     unsubscribe();
   });
 
+  it("should propagate source staleness through a nested derive chain", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    let failUpstream: (error: Error) => void = () => {};
+    const sourceSignal = LazySignal.create("cached", (setDownstream, errorListener) => {
+      emitUpstream = setDownstream;
+      failUpstream = errorListener;
+      return () => {};
+    });
+    const firstDerivedSignal = LazySignal.deriveFrom(
+      [sourceSignal],
+      sourceValue => `first:${sourceValue}`,
+    );
+    const secondDerivedSignal = LazySignal.deriveFrom(
+      [firstDerivedSignal],
+      sourceValue => `second:${sourceValue}`,
+    );
+    const unsubscribe = secondDerivedSignal.subscribe(() => {});
+
+    emitUpstream("fresh");
+    expect(secondDerivedSignal.isStale()).toBe(false);
+
+    failUpstream(new Error("upstream failed"));
+    expect(firstDerivedSignal.isStale()).toBe(true);
+    expect(secondDerivedSignal.isStale()).toBe(true);
+
+    const pullPromise = secondDerivedSignal.pull();
+    expect(sourceSignal.recoverFromError()).toBe(true);
+    emitUpstream("fresh");
+
+    await expect(pullPromise).resolves.toBe("second:first:fresh");
+    expect(secondDerivedSignal.isStale()).toBe(false);
+    unsubscribe();
+  });
+
   it("should capture a synchronous upstream emission during subscription", async () => {
     const sourceSignal = LazySignal.create("cached", setDownstream => {
       setDownstream("synchronous");
@@ -782,6 +816,47 @@ describe("LazySignal", () => {
 });
 
 describe("asyncDeriveFrom", () => {
+  it("should ignore work started before a source became stale", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    let failUpstream: (error: Error) => void = () => {};
+    const sourceSignal = LazySignal.create("cached", (setDownstream, errorListener) => {
+      emitUpstream = setDownstream;
+      failUpstream = errorListener;
+      return () => {};
+    });
+    const resolvers = new Array<(value: string) => void>();
+    const deriver = jest.fn(
+      (sourceValue: string) =>
+        new Promise<string>(resolve => {
+          resolvers.push(result => resolve(`${sourceValue}:${result}`));
+        }),
+    );
+    const derivedSignal = LazySignal.asyncDeriveFrom("eager", [sourceSignal], deriver);
+    const unsubscribe = derivedSignal.subscribe(() => {});
+
+    emitUpstream("first");
+    resolvers[0]("done");
+    await Promise.resolve();
+    expect(derivedSignal.get()).toBe("first:done");
+
+    emitUpstream("second");
+    failUpstream(new Error("upstream failed"));
+    expect(sourceSignal.recoverFromError()).toBe(true);
+    expect(derivedSignal.isStale()).toBe(true);
+
+    resolvers[1]("outdated");
+    await Promise.resolve();
+    expect(derivedSignal.get()).toBe("first:done");
+    expect(derivedSignal.isStale()).toBe(true);
+
+    emitUpstream("second");
+    resolvers[2]("recovered");
+    await Promise.resolve();
+    expect(derivedSignal.get()).toBe("second:recovered");
+    expect(derivedSignal.isStale()).toBe(false);
+    unsubscribe();
+  });
+
   it("should wait for fresh source data before invoking the deriver", async () => {
     let emitUpstream: (value: string) => void = () => {};
     const sourceSignal = LazySignal.create("cached", setDownstream => {
@@ -834,6 +909,46 @@ describe("blockingAsyncDeriveFromWithThrottling", () => {
 
     return { deriver, invocations };
   }
+
+  it("should ignore work started before a source became stale", async () => {
+    let emitUpstream: (value: string) => void = () => {};
+    let failUpstream: (error: Error) => void = () => {};
+    const sourceSignal = LazySignal.create("cached", (setDownstream, errorListener) => {
+      emitUpstream = setDownstream;
+      failUpstream = errorListener;
+      return () => {};
+    });
+    const { deriver, invocations } = createControllableDeriver<string>();
+    const derivedSignal = LazySignal.blockingAsyncDeriveFromWithThrottling(
+      0,
+      [sourceSignal],
+      deriver,
+    );
+    const unsubscribe = derivedSignal.subscribe(() => {});
+
+    emitUpstream("first");
+    invocations[0].resolve("first-result");
+    await Promise.resolve();
+    expect(derivedSignal.get()).toBe("first-result");
+
+    emitUpstream("second");
+    failUpstream(new Error("upstream failed"));
+    expect(sourceSignal.recoverFromError()).toBe(true);
+    expect(derivedSignal.isStale()).toBe(true);
+
+    invocations[1].resolve("outdated-result");
+    await Promise.resolve();
+    expect(derivedSignal.get()).toBe("first-result");
+    expect(derivedSignal.isStale()).toBe(true);
+
+    emitUpstream("second");
+    expect(invocations).toHaveLength(3);
+    invocations[2].resolve("recovered-result");
+    await Promise.resolve();
+    expect(derivedSignal.get()).toBe("recovered-result");
+    expect(derivedSignal.isStale()).toBe(false);
+    unsubscribe();
+  });
 
   it("should wait for fresh source data before invoking the deriver", () => {
     let emitUpstream: (value: string) => void = () => {};

--- a/packages/lms-common/src/LazySignal.ts
+++ b/packages/lms-common/src/LazySignal.ts
@@ -43,6 +43,8 @@ export type SubscribeUpstream<TData> = (
  */
 export class LazySignal<TData> extends Subscribable<TData> implements SignalLike<TData> {
   public readonly [isLazySignalSymbol] = true;
+  public static isLazySignal<TData>(value: SignalLike<TData>): value is LazySignal<TData>;
+  public static isLazySignal(value: unknown): value is LazySignal<unknown>;
   public static isLazySignal(value: unknown): value is LazySignal<unknown> {
     return (
       typeof value === "object" &&
@@ -96,6 +98,44 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     );
   }
 
+  private static subscribeToSources<TSource extends Array<unknown>>(
+    sourceSignals: { [TKey in keyof TSource]: SignalLike<TSource[TKey]> },
+    onSourceValuesChanged: () => void,
+  ): () => void {
+    let pendingSourceRefreshes = 0;
+    let sourceSubscriptionsReady = false;
+    const freshnessUnsubscribers = new Array<() => void>();
+    for (const sourceSignal of sourceSignals) {
+      if (LazySignal.isLazySignal(sourceSignal) && sourceSignal.isStale()) {
+        pendingSourceRefreshes++;
+        freshnessUnsubscribers.push(
+          sourceSignal.updateReceivedEvent.subscribeOnce(() => {
+            pendingSourceRefreshes--;
+            if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
+              onSourceValuesChanged();
+            }
+          }),
+        );
+      }
+    }
+    const sourceUnsubscribers = sourceSignals.map(sourceSignal =>
+      sourceSignal.subscribe(() => {
+        if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
+          onSourceValuesChanged();
+        }
+      }),
+    );
+    sourceSubscriptionsReady = true;
+    if (pendingSourceRefreshes === 0) {
+      onSourceValuesChanged();
+    }
+
+    return () => {
+      sourceUnsubscribers.forEach(unsubscribe => unsubscribe());
+      freshnessUnsubscribers.forEach(unsubscribe => unsubscribe());
+    };
+  }
+
   public static deriveFrom<TSource extends Array<unknown>, TData>(
     sourceSignals: { [TKey in keyof TSource]: SignalLike<TSource[TKey]> },
     deriver: (
@@ -131,23 +171,13 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     };
     return new LazySignal(
       derive(),
-      setDownstream => {
-        const unsubscriber = sourceSignals.map(signal =>
-          signal.subscribe(() => {
-            const value = derive();
-            if (isAvailable(value)) {
-              setDownstream(value);
-            }
-          }),
-        );
-        const newValue = derive();
-        if (isAvailable(newValue)) {
-          setDownstream(newValue);
-        }
-        return () => {
-          unsubscriber.forEach(unsub => unsub());
-        };
-      },
+      setDownstream =>
+        LazySignal.subscribeToSources(sourceSignals, () => {
+          const value = derive();
+          if (isAvailable(value)) {
+            setDownstream(value);
+          }
+        }),
       fullEqualsPredicate,
     ) as any;
   }
@@ -204,15 +234,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
             }
           });
         };
-        const unsubscriber = sourceSignals.map(signal =>
-          signal.subscribe(() => {
-            deriveAndUpdate();
-          }),
-        );
-        deriveAndUpdate();
-        return () => {
-          unsubscriber.forEach(unsub => unsub());
-        };
+        return LazySignal.subscribeToSources(sourceSignals, deriveAndUpdate);
       },
       fullEqualsPredicate,
     );
@@ -345,8 +367,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
           }
         };
 
-        const unsubscribers = sourceSignals.map(signal => signal.subscribe(onSourceChange));
-        onSourceChange();
+        const unsubscribeFromSources = LazySignal.subscribeToSources(sourceSignals, onSourceChange);
 
         return () => {
           subscribed = false;
@@ -357,7 +378,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
             clearTimeout(throttleTimeoutId);
             throttleTimeoutId = null;
           }
-          unsubscribers.forEach(unsubscribe => unsubscribe());
+          unsubscribeFromSources();
         };
       },
       fullEqualsPredicate,
@@ -530,20 +551,44 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
    * If the data is not stale, the callback will be called synchronously with the current value.
    *
    * If the data is stale, it will pull the current value and call the callback with the value.
+   * Returns a function that cancels the pending callback and temporary subscription.
    */
-  public runOnNextFreshData(callback: (value: StripNotAvailable<TData>) => void) {
+  public runOnNextFreshData(
+    callback: (value: StripNotAvailable<TData>) => void,
+  ): () => void {
     if (!this.isStale()) {
       callback(this.get() as StripNotAvailable<TData>);
-    } else {
-      let unsubscribe: (() => void) | null = null;
-      const updateCallback = () => {
-        this.updateReceivedSynchronousCallbacks.delete(updateCallback);
-        callback(this.get() as StripNotAvailable<TData>);
-        unsubscribe?.();
-      };
-      this.updateReceivedSynchronousCallbacks.add(updateCallback);
-      unsubscribe = this.subscribe(() => {});
+      return () => {};
     }
+
+    let active = true;
+    let unsubscribe: (() => void) | null = null;
+    const updateCallback = () => {
+      if (!active) {
+        return;
+      }
+      active = false;
+      this.updateReceivedSynchronousCallbacks.delete(updateCallback);
+      try {
+        callback(this.get() as StripNotAvailable<TData>);
+      } finally {
+        unsubscribe?.();
+      }
+    };
+    this.updateReceivedSynchronousCallbacks.add(updateCallback);
+    unsubscribe = this.subscribe(() => {});
+    if (!active) {
+      unsubscribe();
+    }
+
+    return () => {
+      if (!active) {
+        return;
+      }
+      active = false;
+      this.updateReceivedSynchronousCallbacks.delete(updateCallback);
+      unsubscribe?.();
+    };
   }
 
   public async ensureAvailable(): Promise<LazySignal<StripNotAvailable<TData>>> {

--- a/packages/lms-common/src/LazySignal.ts
+++ b/packages/lms-common/src/LazySignal.ts
@@ -200,6 +200,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     ) as any;
   }
 
+  /** Derives asynchronously and ignores results invalidated by a newer source state. */
   public static asyncDeriveFrom<TSource extends Array<unknown>, TData>(
     strategy: AsyncDeriveFromStrategy,
     sourceSignals: { [TKey in keyof TSource]: SignalLike<TSource[TKey]> },
@@ -253,6 +254,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
           });
         };
         return LazySignal.subscribeToSources(sourceSignals, deriveAndUpdate, () => {
+          // Work started before a source became stale must not make the output fresh again.
           lastAppliedUpdateId = ++lastIssuedUpdateId;
           markDownstreamStale();
         });
@@ -394,6 +396,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
           sourceSignals,
           onSourceChange,
           () => {
+            // Drop queued and in-flight work that was based on a subscription which is now stale.
             freshnessGeneration++;
             pending = null;
             if (throttleTimeoutId !== null) {
@@ -420,6 +423,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     );
   }
 
+  /** Creates the lazy signal state shared by the public factory methods. */
   protected constructor(
     initialValue: TData,
     private readonly subscribeUpstream: SubscribeUpstream<TData>,
@@ -489,6 +493,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     return true;
   }
 
+  /** Starts the upstream subscription and tracks its freshness and errors. */
   private subscribeToUpstream() {
     if (this.hasEncounteredError) {
       return;
@@ -537,6 +542,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     };
   }
 
+  /** Stops the active upstream subscription and marks its cached value stale. */
   private unsubscribeFromUpstream() {
     this.isSubscribedToUpstream = false;
     if (this.upstreamUnsubscribe !== null) {

--- a/packages/lms-common/src/LazySignal.ts
+++ b/packages/lms-common/src/LazySignal.ts
@@ -1,4 +1,10 @@
-import { Signal, type SignalFullSubscriber, type SignalLike, type Subscriber } from "./Signal.js";
+import {
+  Signal,
+  type SignalFullSubscriber,
+  type SignalFullSubscriberWithFreshness,
+  type SignalLike,
+  type Subscriber,
+} from "./Signal.js";
 import { Subscribable } from "./Subscribable.js";
 import { makePromise } from "./makePromise.js";
 import { makeSetterWithPatches, type Setter } from "./makeSetter.js";
@@ -583,9 +589,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
    * If the data is stale, it will pull the current value and call the callback with the value.
    * Returns a function that cancels the pending callback and temporary subscription.
    */
-  public runOnNextFreshData(
-    callback: (value: StripNotAvailable<TData>) => void,
-  ): () => void {
+  public runOnNextFreshData(callback: (value: StripNotAvailable<TData>) => void): () => void {
     if (!this.isStale()) {
       callback(this.get() as StripNotAvailable<TData>);
       return () => {};
@@ -663,6 +667,18 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
         this.unsubscribeFromUpstream();
       }
     };
+  }
+
+  /**
+   * Marks upstream value packets as fresh even though staleSignal changes after value subscribers
+   * run. Every accepted packet from a LazySignal's upstream restores freshness.
+   */
+  public subscribeFullWithFreshness(
+    subscriber: SignalFullSubscriberWithFreshness<TData>,
+  ): () => void {
+    return this.subscribeFull((value, patches, tags) => {
+      subscriber(value, patches, tags, true);
+    });
   }
 
   /**

--- a/packages/lms-common/src/LazySignal.ts
+++ b/packages/lms-common/src/LazySignal.ts
@@ -1,13 +1,7 @@
-import {
-  Signal,
-  type SignalFullSubscriber,
-  type SignalFullSubscriberWithFreshness,
-  type SignalLike,
-  type Subscriber,
-} from "./Signal.js";
+import { Signal, type SignalFullSubscriber, type SignalLike, type Subscriber } from "./Signal.js";
 import { Subscribable } from "./Subscribable.js";
 import { makePromise } from "./makePromise.js";
-import { makeSetterWithPatches, type Setter } from "./makeSetter.js";
+import { makeSetterWithPatches, type Setter, type WriteTag } from "./makeSetter.js";
 
 const isLazySignalSymbol = Symbol("isLazySignal");
 export type NotAvailable = typeof LazySignal.NOT_AVAILABLE;
@@ -39,7 +33,7 @@ export type SubscribeUpstream<TData> = (
    * Marks the downstream value stale without ending its subscription. Composed signals use this
    * while one of their sources is waiting to recover.
    */
-  markDownstreamStale: () => void,
+  markDownstreamStale: (tags?: Array<WriteTag>) => void,
 ) => () => void;
 
 /**
@@ -64,10 +58,10 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
   }
   public static readonly NOT_AVAILABLE = Symbol("notAvailable");
   private readonly signal: Signal<TData>;
-  private readonly setValue: Setter<TData>;
+  private readonly setFreshValue: Setter<TData>;
   /** Tracks whether the cached value is current for the active upstream subscription. */
   public readonly staleSignal: Signal<boolean>;
-  private readonly setStale: Setter<boolean>;
+  private readonly markStale: (tags?: Array<WriteTag>) => void;
   private upstreamUnsubscribe: (() => void) | null = null;
   private subscribersCount = 0;
   private isSubscribedToUpstream = false;
@@ -114,11 +108,9 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
   ): () => void {
     let sourceSubscriptionsReady = false;
 
-    /** Updates the downstream value or marks it stale if any source is stale. */
+    /** Updates the downstream value only when every source is fresh. */
     const updateIfSourcesAreFresh = () => {
-      if (sourceSignals.some(sourceSignal => sourceSignal.staleSignal?.get() === true)) {
-        markDownstreamStale();
-      } else {
+      if (sourceSignals.every(sourceSignal => sourceSignal.staleSignal?.get() !== true)) {
         onSourceValuesChanged();
       }
     };
@@ -136,19 +128,18 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
       }
       return [
         sourceSignal.staleSignal.subscribe(sourceIsStale => {
-          if (!sourceSubscriptionsReady) {
-            return;
-          }
-          if (sourceIsStale) {
+          if (sourceSubscriptionsReady && sourceIsStale) {
             markDownstreamStale();
-          } else {
-            updateIfSourcesAreFresh();
           }
         }),
       ];
     });
     sourceSubscriptionsReady = true;
-    updateIfSourcesAreFresh();
+    if (sourceSignals.some(sourceSignal => sourceSignal.staleSignal?.get() === true)) {
+      markDownstreamStale();
+    } else {
+      onSourceValuesChanged();
+    }
 
     return () => {
       freshnessUnsubscribers.forEach(unsubscribe => unsubscribe());
@@ -436,8 +427,11 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     equalsPredicate: (a: TData, b: TData) => boolean = (a, b) => a === b,
   ) {
     super();
-    [this.signal, this.setValue] = Signal.create<TData>(initialValue, equalsPredicate) as any;
-    [this.staleSignal, this.setStale] = Signal.create(true);
+    const state = Signal.createWithStaleState(initialValue, true, equalsPredicate);
+    this.signal = state.signal;
+    this.setFreshValue = state.setFreshValue;
+    this.staleSignal = state.signal.staleSignal!;
+    this.markStale = state.markStale;
     [this.errorSignal, this.setError] = Signal.create<Error | null>(null);
   }
 
@@ -488,7 +482,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     }
 
     this.hasEncounteredError = false;
-    this.setStale(true);
+    this.markStale();
     this.setError(null);
 
     // If we have subscribers, immediately try to reconnect
@@ -506,14 +500,11 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     }
     this.isSubscribedToUpstream = true;
     let subscribed = true;
-    let becameStale = false;
     const unsubscribeFromUpstream = this.subscribeUpstream(
       makeSetterWithPatches((updater, tags) => {
-        if (!subscribed) {
-          return;
+        if (subscribed) {
+          this.setFreshValue.withPatchUpdater(updater, tags);
         }
-        this.setValue.withPatchUpdater(updater, tags);
-        this.setStale(becameStale);
       }),
       error => {
         if (!subscribed) {
@@ -527,22 +518,20 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
           this.hasEncounteredError = true;
           this.setError(normalizedError);
         }
-        this.setStale(true);
+        this.markStale();
         this.isSubscribedToUpstream = false;
         this.upstreamUnsubscribe = null;
-        becameStale = true;
         subscribed = false;
       },
-      () => {
+      tags => {
         if (subscribed) {
-          this.setStale(true);
+          this.markStale(tags);
         }
       },
     );
     this.upstreamUnsubscribe = () => {
       if (subscribed) {
         subscribed = false;
-        becameStale = true;
         unsubscribeFromUpstream();
       }
     };
@@ -554,7 +543,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     if (this.upstreamUnsubscribe !== null) {
       this.upstreamUnsubscribe();
       this.upstreamUnsubscribe = null;
-      this.setStale(true);
+      this.markStale();
     }
   }
 
@@ -667,18 +656,6 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
         this.unsubscribeFromUpstream();
       }
     };
-  }
-
-  /**
-   * Marks upstream value packets as fresh even though staleSignal changes after value subscribers
-   * run. Every accepted packet from a LazySignal's upstream restores freshness.
-   */
-  public subscribeFullWithFreshness(
-    subscriber: SignalFullSubscriberWithFreshness<TData>,
-  ): () => void {
-    return this.subscribeFull((value, patches, tags) => {
-      subscriber(value, patches, tags, true);
-    });
   }
 
   /**

--- a/packages/lms-common/src/LazySignal.ts
+++ b/packages/lms-common/src/LazySignal.ts
@@ -135,7 +135,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     const sourceUnsubscribers = sourceSignals.map(sourceSignal =>
       sourceSignal.subscribe(() => {
         if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
-          onSourceValuesChanged();
+          updateOrWaitForStaleSources();
         }
       }),
     );

--- a/packages/lms-common/src/LazySignal.ts
+++ b/packages/lms-common/src/LazySignal.ts
@@ -1,6 +1,5 @@
 import { Signal, type SignalFullSubscriber, type SignalLike, type Subscriber } from "./Signal.js";
 import { Subscribable } from "./Subscribable.js";
-import { SyncEvent } from "./SyncEvent.js";
 import { makePromise } from "./makePromise.js";
 import { makeSetterWithPatches, type Setter } from "./makeSetter.js";
 
@@ -30,6 +29,11 @@ export type SubscribeUpstream<TData> = (
    * the unsubscriber will NOT be called.
    */
   errorListener: (error: any) => void,
+  /**
+   * Marks the downstream value stale without ending its subscription. Composed signals use this
+   * while one of their sources is waiting to recover.
+   */
+  markDownstreamStale: () => void,
 ) => () => void;
 
 /**
@@ -55,7 +59,9 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
   public static readonly NOT_AVAILABLE = Symbol("notAvailable");
   private readonly signal: Signal<TData>;
   private readonly setValue: Setter<TData>;
-  private dataIsStale = true;
+  /** Tracks whether the cached value is current for the active upstream subscription. */
+  public readonly staleSignal: Signal<boolean>;
+  private readonly setStale: Setter<boolean>;
   private upstreamUnsubscribe: (() => void) | null = null;
   private subscribersCount = 0;
   private isSubscribedToUpstream = false;
@@ -66,12 +72,6 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
    */
   public readonly errorSignal: Signal<Error | null>;
   private readonly setError: Setter<Error | null>;
-  /**
-   * This event will be triggered even if the value did not change. This is for resolving .pull.
-   */
-  private readonly updateReceivedEvent: SyncEvent<void>;
-  private readonly emitUpdateReceivedEvent: () => void;
-  private readonly updateReceivedSynchronousCallbacks = new Set<() => void>();
 
   public static create<TData>(
     initialValue: TData,
@@ -99,54 +99,54 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
   }
 
   /**
-   * Subscribes to each source and runs the update only after every source has fresh data.
+   * Subscribes to each source and runs the update only while every source has fresh data.
    */
   private static subscribeToSources<TSource extends Array<unknown>>(
     sourceSignals: { [TKey in keyof TSource]: SignalLike<TSource[TKey]> },
     onSourceValuesChanged: () => void,
+    markDownstreamStale: () => void,
   ): () => void {
-    let pendingSourceRefreshes = 0;
     let sourceSubscriptionsReady = false;
-    const freshnessUnsubscribers = new Array<() => void>();
 
-    /** Runs the update now or waits for every stale source to refresh. */
-    const updateOrWaitForStaleSources = () => {
-      // A source may have refreshed and then failed while another source was still pending. Check
-      // the whole group again before treating it as fresh.
-      for (const sourceSignal of sourceSignals) {
-        if (LazySignal.isLazySignal(sourceSignal) && sourceSignal.isStale()) {
-          pendingSourceRefreshes++;
-          freshnessUnsubscribers.push(
-            sourceSignal.updateReceivedEvent.subscribeOnce(() => {
-              pendingSourceRefreshes--;
-              if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
-                updateOrWaitForStaleSources();
-              }
-            }),
-          );
-        }
-      }
-      if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
+    /** Updates the downstream value or marks it stale if any source is stale. */
+    const updateIfSourcesAreFresh = () => {
+      if (sourceSignals.some(sourceSignal => sourceSignal.staleSignal?.get() === true)) {
+        markDownstreamStale();
+      } else {
         onSourceValuesChanged();
       }
     };
 
-    updateOrWaitForStaleSources();
     const sourceUnsubscribers = sourceSignals.map(sourceSignal =>
       sourceSignal.subscribe(() => {
-        if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
-          updateOrWaitForStaleSources();
+        if (sourceSubscriptionsReady) {
+          updateIfSourcesAreFresh();
         }
       }),
     );
+    const freshnessUnsubscribers = sourceSignals.flatMap(sourceSignal => {
+      if (sourceSignal.staleSignal === undefined) {
+        return [];
+      }
+      return [
+        sourceSignal.staleSignal.subscribe(sourceIsStale => {
+          if (!sourceSubscriptionsReady) {
+            return;
+          }
+          if (sourceIsStale) {
+            markDownstreamStale();
+          } else {
+            updateIfSourcesAreFresh();
+          }
+        }),
+      ];
+    });
     sourceSubscriptionsReady = true;
-    if (pendingSourceRefreshes === 0) {
-      updateOrWaitForStaleSources();
-    }
+    updateIfSourcesAreFresh();
 
     return () => {
-      sourceUnsubscribers.forEach(unsubscribe => unsubscribe());
       freshnessUnsubscribers.forEach(unsubscribe => unsubscribe());
+      sourceUnsubscribers.forEach(unsubscribe => unsubscribe());
     };
   }
 
@@ -185,13 +185,17 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     };
     return new LazySignal(
       derive(),
-      setDownstream =>
-        LazySignal.subscribeToSources(sourceSignals, () => {
-          const value = derive();
-          if (isAvailable(value)) {
-            setDownstream(value);
-          }
-        }),
+      (setDownstream, _errorListener, markDownstreamStale) =>
+        LazySignal.subscribeToSources(
+          sourceSignals,
+          () => {
+            const value = derive();
+            if (isAvailable(value)) {
+              setDownstream(value);
+            }
+          },
+          markDownstreamStale,
+        ),
       fullEqualsPredicate,
     ) as any;
   }
@@ -221,7 +225,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     let lastIssuedUpdateId = -1;
     return new LazySignal<TData | NotAvailable>(
       LazySignal.NOT_AVAILABLE,
-      setDownstream => {
+      (setDownstream, _errorListener, markDownstreamStale) => {
         const deriveAndUpdate = () => {
           lastIssuedUpdateId++;
           const updateId = lastIssuedUpdateId;
@@ -248,7 +252,10 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
             }
           });
         };
-        return LazySignal.subscribeToSources(sourceSignals, deriveAndUpdate);
+        return LazySignal.subscribeToSources(sourceSignals, deriveAndUpdate, () => {
+          lastAppliedUpdateId = ++lastIssuedUpdateId;
+          markDownstreamStale();
+        });
       },
       fullEqualsPredicate,
     );
@@ -302,8 +309,9 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
 
     return new LazySignal<TData | NotAvailable>(
       LazySignal.NOT_AVAILABLE,
-      setDownstream => {
+      (setDownstream, _errorListener, markDownstreamStale) => {
         let subscribed = true;
+        let freshnessGeneration = 0;
 
         const processPending = () => {
           throttleTimeoutId = null;
@@ -336,6 +344,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
 
         const startDerive = (sourceValues: Array<unknown>) => {
           isRunning = true;
+          const deriveFreshnessGeneration = freshnessGeneration;
           let promise: Promise<TData>;
           try {
             promise = deriver(...(sourceValues as any));
@@ -349,7 +358,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
             }
             isRunning = false;
             lastDeriveCompletedAt = Date.now();
-            if (isAvailable(result)) {
+            if (deriveFreshnessGeneration === freshnessGeneration && isAvailable(result)) {
               setDownstream(result);
             }
             advanceQueue();
@@ -381,7 +390,19 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
           }
         };
 
-        const unsubscribeFromSources = LazySignal.subscribeToSources(sourceSignals, onSourceChange);
+        const unsubscribeFromSources = LazySignal.subscribeToSources(
+          sourceSignals,
+          onSourceChange,
+          () => {
+            freshnessGeneration++;
+            pending = null;
+            if (throttleTimeoutId !== null) {
+              clearTimeout(throttleTimeoutId);
+              throttleTimeoutId = null;
+            }
+            markDownstreamStale();
+          },
+        );
 
         return () => {
           subscribed = false;
@@ -405,9 +426,8 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     equalsPredicate: (a: TData, b: TData) => boolean = (a, b) => a === b,
   ) {
     super();
-    // Initialize with dummy values, will be set by resetErrorPromise
     [this.signal, this.setValue] = Signal.create<TData>(initialValue, equalsPredicate) as any;
-    [this.updateReceivedEvent, this.emitUpdateReceivedEvent] = SyncEvent.create();
+    [this.staleSignal, this.setStale] = Signal.create(true);
     [this.errorSignal, this.setError] = Signal.create<Error | null>(null);
   }
 
@@ -428,7 +448,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
    * {@link LazySignal#pull}.
    */
   public isStale() {
-    return this.dataIsStale;
+    return this.staleSignal.get();
   }
 
   /**
@@ -458,7 +478,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     }
 
     this.hasEncounteredError = false;
-    this.dataIsStale = true;
+    this.setStale(true);
     this.setError(null);
 
     // If we have subscribers, immediately try to reconnect
@@ -482,11 +502,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
           return;
         }
         this.setValue.withPatchUpdater(updater, tags);
-        this.dataIsStale = becameStale;
-        this.emitUpdateReceivedEvent();
-        for (const callback of this.updateReceivedSynchronousCallbacks) {
-          callback();
-        }
+        this.setStale(becameStale);
       }),
       error => {
         if (!subscribed) {
@@ -500,11 +516,16 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
           this.hasEncounteredError = true;
           this.setError(normalizedError);
         }
-        this.dataIsStale = true;
+        this.setStale(true);
         this.isSubscribedToUpstream = false;
         this.upstreamUnsubscribe = null;
         becameStale = true;
         subscribed = false;
+      },
+      () => {
+        if (subscribed) {
+          this.setStale(true);
+        }
       },
     );
     this.upstreamUnsubscribe = () => {
@@ -521,7 +542,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     if (this.upstreamUnsubscribe !== null) {
       this.upstreamUnsubscribe();
       this.upstreamUnsubscribe = null;
-      this.dataIsStale = true;
+      this.setStale(true);
     }
   }
 
@@ -546,18 +567,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
    */
   public async pull(): Promise<StripNotAvailable<TData>> {
     const { promise, resolve } = makePromise<StripNotAvailable<TData>>();
-    if (!this.isStale()) {
-      // If not stale, definitely not "NOT_AVAILABLE"
-      resolve(this.get() as StripNotAvailable<TData>);
-    } else {
-      // Register event listener BEFORE subscribe() because subscribe() may trigger
-      // subscribeToUpstream() which can emit the event synchronously
-      this.updateReceivedEvent.subscribeOnce(() => {
-        resolve(this.get() as StripNotAvailable<TData>);
-      });
-      const unsubscribe = this.subscribe(() => {});
-      promise.then(unsubscribe);
-    }
+    this.runOnNextFreshData(resolve);
     return promise;
   }
 
@@ -576,23 +586,22 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     }
 
     let active = true;
-    let unsubscribe: (() => void) | null = null;
-    const updateCallback = () => {
-      if (!active) {
+    let unsubscribeSignal: (() => void) | null = null;
+    const unsubscribeStaleSignal = this.staleSignal.subscribe(isStale => {
+      if (!active || isStale) {
         return;
       }
       active = false;
-      this.updateReceivedSynchronousCallbacks.delete(updateCallback);
+      unsubscribeStaleSignal();
       try {
         callback(this.get() as StripNotAvailable<TData>);
       } finally {
-        unsubscribe?.();
+        unsubscribeSignal?.();
       }
-    };
-    this.updateReceivedSynchronousCallbacks.add(updateCallback);
-    unsubscribe = this.subscribe(() => {});
+    });
+    unsubscribeSignal = this.subscribe(() => {});
     if (!active) {
-      unsubscribe();
+      unsubscribeSignal();
     }
 
     return () => {
@@ -600,8 +609,8 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
         return;
       }
       active = false;
-      this.updateReceivedSynchronousCallbacks.delete(updateCallback);
-      unsubscribe?.();
+      unsubscribeStaleSignal();
+      unsubscribeSignal?.();
     };
   }
 

--- a/packages/lms-common/src/LazySignal.ts
+++ b/packages/lms-common/src/LazySignal.ts
@@ -98,6 +98,9 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     );
   }
 
+  /**
+   * Subscribes to each source and runs the update only after every source has fresh data.
+   */
   private static subscribeToSources<TSource extends Array<unknown>>(
     sourceSignals: { [TKey in keyof TSource]: SignalLike<TSource[TKey]> },
     onSourceValuesChanged: () => void,
@@ -105,19 +108,30 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     let pendingSourceRefreshes = 0;
     let sourceSubscriptionsReady = false;
     const freshnessUnsubscribers = new Array<() => void>();
-    for (const sourceSignal of sourceSignals) {
-      if (LazySignal.isLazySignal(sourceSignal) && sourceSignal.isStale()) {
-        pendingSourceRefreshes++;
-        freshnessUnsubscribers.push(
-          sourceSignal.updateReceivedEvent.subscribeOnce(() => {
-            pendingSourceRefreshes--;
-            if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
-              onSourceValuesChanged();
-            }
-          }),
-        );
+
+    /** Runs the update now or waits for every stale source to refresh. */
+    const updateOrWaitForStaleSources = () => {
+      // A source may have refreshed and then failed while another source was still pending. Check
+      // the whole group again before treating it as fresh.
+      for (const sourceSignal of sourceSignals) {
+        if (LazySignal.isLazySignal(sourceSignal) && sourceSignal.isStale()) {
+          pendingSourceRefreshes++;
+          freshnessUnsubscribers.push(
+            sourceSignal.updateReceivedEvent.subscribeOnce(() => {
+              pendingSourceRefreshes--;
+              if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
+                updateOrWaitForStaleSources();
+              }
+            }),
+          );
+        }
       }
-    }
+      if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
+        onSourceValuesChanged();
+      }
+    };
+
+    updateOrWaitForStaleSources();
     const sourceUnsubscribers = sourceSignals.map(sourceSignal =>
       sourceSignal.subscribe(() => {
         if (sourceSubscriptionsReady && pendingSourceRefreshes === 0) {
@@ -127,7 +141,7 @@ export class LazySignal<TData> extends Subscribable<TData> implements SignalLike
     );
     sourceSubscriptionsReady = true;
     if (pendingSourceRefreshes === 0) {
-      onSourceValuesChanged();
+      updateOrWaitForStaleSources();
     }
 
     return () => {

--- a/packages/lms-common/src/OWLSignal.test.ts
+++ b/packages/lms-common/src/OWLSignal.test.ts
@@ -274,6 +274,35 @@ describe("OWLSignal Write Loop Error Recovery", () => {
       expect(signal.get()).toEqual({ count: 4 });
     });
 
+    it("should roll back a failed write while the inner signal remains fresh", async () => {
+      const mock = createMockUpstream<{ count: number }>();
+      const [signal, setter, emitWriteError] = OWLSignal.create(
+        { count: 0 },
+        mock.subscribeUpstream,
+        mock.writeUpstream,
+      );
+      const callbackFull = jest.fn();
+      signal.subscribeFull(callbackFull);
+
+      mock.simulateUpdate({ count: 0 });
+      callbackFull.mockClear();
+
+      setter({ count: 1 }, ["failed-write"]);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(signal.get()).toEqual({ count: 1 });
+
+      emitWriteError(mock.getLastWrite().tags, new Error("write rejected"));
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(signal.isStale()).toBe(false);
+      expect(signal.get()).toEqual({ count: 0 });
+      expect(callbackFull).toHaveBeenLastCalledWith(
+        { count: 0 },
+        [{ op: "replace", path: [], value: { count: 0 } }],
+        ["failed-write"],
+      );
+    });
+
     it("should flush pending write tags to full subscribers on transport error", async () => {
       const mock = createMockUpstream<{ count: number }>();
       const [signal, setter] = OWLSignal.create(

--- a/packages/lms-common/src/OWLSignal.test.ts
+++ b/packages/lms-common/src/OWLSignal.test.ts
@@ -105,6 +105,84 @@ describe("OWLSignal Write Loop Error Recovery", () => {
       expect(signal.get()).toEqual({ count: 1 });
     });
 
+    it("should settle once when writeUpstream confirms synchronously and returns false", async () => {
+      const initialValue = { count: 0 };
+      let emitUpstream!: Setter<typeof initialValue>;
+      let writeCount = 0;
+      const [signal, setter] = OWLSignal.create(
+        initialValue,
+        setDownstream => {
+          emitUpstream = setDownstream;
+          return () => {};
+        },
+        (data, patches, tags) => {
+          writeCount++;
+          emitUpstream.withValueAndPatches(data, patches, tags);
+          return false;
+        },
+      );
+      signal.subscribe(() => {});
+      emitUpstream(initialValue);
+
+      setter.withProducer(draft => {
+        draft.count = 1;
+      });
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(writeCount).toBe(1);
+      expect(signal.get()).toEqual({ count: 1 });
+      expect(signal.isStale()).toBe(false);
+    });
+
+    it("should start one write loop when subscribing produces a synchronous value", async () => {
+      const initialValue = { count: 0 };
+      let writeCount = 0;
+      const [signal, setter] = OWLSignal.create(
+        initialValue,
+        setDownstream => {
+          setDownstream(initialValue);
+          return () => {};
+        },
+        () => {
+          writeCount++;
+          return false;
+        },
+      );
+
+      setter.withProducer(draft => {
+        draft.count = 1;
+      });
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(writeCount).toBe(1);
+      expect(signal.isStale()).toBe(true);
+    });
+
+    it("should forward stale inner tags without restoring outer freshness", () => {
+      const initialValue = { count: 0 };
+      let emitUpstream!: Setter<typeof initialValue>;
+      let markUpstreamStale!: (tags?: Array<WriteTag>) => void;
+      const [signal] = OWLSignal.create(
+        initialValue,
+        (setDownstream, _errorListener, markDownstreamStale) => {
+          emitUpstream = setDownstream;
+          markUpstreamStale = markDownstreamStale;
+          return () => {};
+        },
+        () => true,
+      );
+      const callbackFull = jest.fn();
+      signal.subscribeFull(callbackFull);
+      emitUpstream(initialValue);
+      callbackFull.mockClear();
+
+      markUpstreamStale(["stale-tag"]);
+
+      expect(signal.isStale()).toBe(true);
+      expect(signal.get()).toEqual(initialValue);
+      expect(callbackFull).toHaveBeenCalledWith(initialValue, [], ["stale-tag"]);
+    });
+
     it("should batch multiple rapid writes", async () => {
       const mock = createMockUpstream<{ count: number }>();
       const [signal, setter] = OWLSignal.create(

--- a/packages/lms-common/src/OWLSignal.ts
+++ b/packages/lms-common/src/OWLSignal.ts
@@ -47,6 +47,8 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
    * The inner signal used to subscribe to the upstream
    */
   private readonly innerSignal: LazySignal<TData>;
+  /** Reports whether the latest upstream value is still current. */
+  public readonly staleSignal: Signal<boolean>;
   /**
    * The outer signal used to notify subscribers of the value (after applying optimistic updates)
    */
@@ -111,6 +113,7 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
     [this.writeErrorEvent, this.emitWriteErrorEvent] = Event.create();
     [this.outerSignal, this.setOuterSignal] = Signal.create(initialValue, equalsPredicate);
     this.innerSignal = LazySignal.create(initialValue, subscribeUpstream, equalsPredicate);
+    this.staleSignal = this.innerSignal.staleSignal;
     this.innerSignal.passiveSubscribeFull((_data, _patches, tags) => {
       if (this.isSubscriptionHandledByWriteLoop) {
         return;

--- a/packages/lms-common/src/OWLSignal.ts
+++ b/packages/lms-common/src/OWLSignal.ts
@@ -9,7 +9,13 @@ import {
 } from "./LazySignal.js";
 import { makePromise } from "./makePromise.js";
 import { makeSetterWithPatches, type Setter, type WriteTag } from "./makeSetter.js";
-import { Signal, type SignalFullSubscriber, type SignalLike, type Subscriber } from "./Signal.js";
+import {
+  Signal,
+  type SignalFullSubscriber,
+  type SignalFullSubscriberWithFreshness,
+  type SignalLike,
+  type Subscriber,
+} from "./Signal.js";
 import { Subscribable } from "./Subscribable.js";
 
 interface WriteError {
@@ -57,6 +63,8 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
    * The setter function to update the value of the signal.
    */
   private readonly setOuterSignal: Setter<TData>;
+  /** Freshness attached to the outer update currently notifying subscribers. */
+  private outerUpdateIsFresh: boolean | null = null;
   private isWriteLoopRunning = false;
   /**
    * We have a passive subscription to the inner signal to update the optimistic value whenever the
@@ -91,12 +99,25 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
     return data;
   }
 
-  private updateOptimisticValue(tags?: Array<WriteTag>) {
+  /**
+   * Rebuilds the optimistic value and records whether its base value is fresh. Updates caused by an
+   * inner value packet pass true because that packet restores the inner signal's freshness.
+   */
+  private updateOptimisticValue(
+    tags?: Array<WriteTag>,
+    isFresh = this.outerUpdateIsFresh ?? !this.isStale(),
+  ) {
     const innerValue = this.innerSignal.get();
     if (!isAvailable(innerValue)) {
       return;
     }
-    this.setOuterSignal(this.applyOptimisticUpdates(innerValue), tags);
+    const previousOuterUpdateIsFresh = this.outerUpdateIsFresh;
+    this.outerUpdateIsFresh = isFresh;
+    try {
+      this.setOuterSignal(this.applyOptimisticUpdates(innerValue), tags);
+    } finally {
+      this.outerUpdateIsFresh = previousOuterUpdateIsFresh;
+    }
   }
 
   /** Creates the optimistic wrapper around its lazy upstream signal. */
@@ -119,7 +140,7 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
       if (this.isSubscriptionHandledByWriteLoop) {
         return;
       }
-      this.updateOptimisticValue(tags);
+      this.updateOptimisticValue(tags, true);
     });
   }
 
@@ -267,11 +288,14 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
                 // If this update is caused by the write, we need to remove the optimistic update
                 // and apply the remaining optimistic updates
                 this.queuedUpdates.splice(0, numQueuedUpdatesToHandle);
-                this.updateOptimisticValue(tags.filter(t => t !== tag));
+                this.updateOptimisticValue(
+                  tags.filter(t => t !== tag),
+                  true,
+                );
               } else {
                 // This update is not caused by the write, simply update the optimistic value
                 // as normal
-                this.updateOptimisticValue(tags);
+                this.updateOptimisticValue(tags, true);
               }
             }),
           );
@@ -435,5 +459,16 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
       unsubscribeOuter();
       unsubscribeInner();
     };
+  }
+
+  /**
+   * Distinguishes optimistic updates made while stale from updates based on a fresh inner value.
+   */
+  public subscribeFullWithFreshness(
+    subscriber: SignalFullSubscriberWithFreshness<TData>,
+  ): () => void {
+    return this.subscribeFull((value, patches, tags) => {
+      subscriber(value, patches, tags, this.outerUpdateIsFresh ?? !this.isStale());
+    });
   }
 }

--- a/packages/lms-common/src/OWLSignal.ts
+++ b/packages/lms-common/src/OWLSignal.ts
@@ -9,13 +9,7 @@ import {
 } from "./LazySignal.js";
 import { makePromise } from "./makePromise.js";
 import { makeSetterWithPatches, type Setter, type WriteTag } from "./makeSetter.js";
-import {
-  Signal,
-  type SignalFullSubscriber,
-  type SignalFullSubscriberWithFreshness,
-  type SignalLike,
-  type Subscriber,
-} from "./Signal.js";
+import { Signal, type SignalFullSubscriber, type SignalLike, type Subscriber } from "./Signal.js";
 import { Subscribable } from "./Subscribable.js";
 
 interface WriteError {
@@ -63,8 +57,8 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
    * The setter function to update the value of the signal.
    */
   private readonly setOuterSignal: Setter<TData>;
-  /** Freshness attached to the outer update currently notifying subscribers. */
-  private outerUpdateIsFresh: boolean | null = null;
+  private readonly setFreshOuterSignal: Setter<TData>;
+  private readonly markOuterStale: (tags?: Array<WriteTag>) => void;
   private isWriteLoopRunning = false;
   /**
    * We have a passive subscription to the inner signal to update the optimistic value whenever the
@@ -99,24 +93,11 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
     return data;
   }
 
-  /**
-   * Rebuilds the optimistic value and records whether its base value is fresh. Updates caused by an
-   * inner value packet pass true because that packet restores the inner signal's freshness.
-   */
-  private updateOptimisticValue(
-    tags?: Array<WriteTag>,
-    isFresh = this.outerUpdateIsFresh ?? !this.isStale(),
-  ) {
+  /** Rebuilds the optimistic value with the setter chosen by the caller. */
+  private updateOptimisticValue(setOuterSignal: Setter<TData>, tags?: Array<WriteTag>) {
     const innerValue = this.innerSignal.get();
-    if (!isAvailable(innerValue)) {
-      return;
-    }
-    const previousOuterUpdateIsFresh = this.outerUpdateIsFresh;
-    this.outerUpdateIsFresh = isFresh;
-    try {
-      this.setOuterSignal(this.applyOptimisticUpdates(innerValue), tags);
-    } finally {
-      this.outerUpdateIsFresh = previousOuterUpdateIsFresh;
+    if (isAvailable(innerValue)) {
+      setOuterSignal(this.applyOptimisticUpdates(innerValue), tags);
     }
   }
 
@@ -133,14 +114,27 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
   ) {
     super();
     [this.writeErrorEvent, this.emitWriteErrorEvent] = Event.create();
-    [this.outerSignal, this.setOuterSignal] = Signal.create(initialValue, equalsPredicate);
+    const outerState = Signal.createWithStaleState(initialValue, true, equalsPredicate);
+    this.outerSignal = outerState.signal;
+    this.setOuterSignal = outerState.setValue;
+    this.setFreshOuterSignal = outerState.setFreshValue;
+    this.markOuterStale = outerState.markStale;
+    this.staleSignal = outerState.signal.staleSignal!;
     this.innerSignal = LazySignal.create(initialValue, subscribeUpstream, equalsPredicate);
-    this.staleSignal = this.innerSignal.staleSignal;
     this.innerSignal.passiveSubscribeFull((_data, _patches, tags) => {
       if (this.isSubscriptionHandledByWriteLoop) {
         return;
       }
-      this.updateOptimisticValue(tags, true);
+      if (this.innerSignal.isStale()) {
+        this.markOuterStale(tags);
+      } else {
+        this.updateOptimisticValue(this.setFreshOuterSignal, tags);
+      }
+    });
+    this.innerSignal.staleSignal.subscribe(isStale => {
+      if (isStale) {
+        this.markOuterStale();
+      }
     });
   }
 
@@ -188,6 +182,7 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
     );
   }
 
+  /** Applies a write optimistically or acknowledges it immediately while errored. */
   private async update(
     updater: (
       oldValue: StripNotAvailable<TData>,
@@ -195,9 +190,7 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
     tags?: Array<WriteTag>,
   ) {
     if (this.hasError()) {
-      if (tags !== undefined && tags.length > 0) {
-        this.setOuterSignal(this.outerSignal.get() as StripNotAvailable<TData>, tags);
-      }
+      this.markOuterStale(tags);
       return Promise.resolve();
     }
     const { promise, reject, resolve } = makePromise<void>();
@@ -207,7 +200,7 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
       resolve,
       reject,
     });
-    this.updateOptimisticValue();
+    this.updateOptimisticValue(this.setOuterSignal);
     this.ensureWriteLoop();
     // FIXME: Don't propagate errors here since setters cannot fail currently.
     return promise.catch(() => {});
@@ -220,39 +213,35 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
       this.writeLoop(); // This is not expected to error, if it does, just default behavior
     }
   }
-  /**
-   * The main write loop, it will keep running until there are no more updates to process.
-   */
+  /** Runs queued writes serially against fresh inner data. */
   private async writeLoop() {
-    const unsubscribe = this.innerSignal.subscribe(() => {});
     this.isWriteLoopRunning = true;
+    let unsubscribe = () => {};
     try {
-      if (this.isStale()) {
-        await this.innerSignal.pull();
-      }
+      unsubscribe = this.innerSignal.subscribe(() => {});
       while (this.queuedUpdates.length > 0) {
-        const numQueuedUpdatesToHandle = this.queuedUpdates.length;
+        if (this.innerSignal.isStale()) {
+          await this.innerSignal.pull();
+        }
+
+        const handledUpdates = this.queuedUpdates.slice();
+        const numHandledUpdates = handledUpdates.length;
         const updater = (data: StripNotAvailable<TData>) => {
           const patches: Array<Patch> = [];
-          for (let i = 0; i < numQueuedUpdatesToHandle; i++) {
-            const [newData, newPatches] = this.queuedUpdates[i].updater(data);
+          for (const update of handledUpdates) {
+            const [newData, newPatches] = update.updater(data);
             data = newData;
             patches.push(...newPatches);
           }
           return [data, patches] as const;
         };
-        const resolve = () => {
-          for (let i = 0; i < numQueuedUpdatesToHandle; i++) {
-            this.queuedUpdates[i].resolve();
-          }
+        const resolveHandledUpdates = () => {
+          handledUpdates.forEach(update => update.resolve());
         };
-        const reject = (error: any) => {
-          for (let i = 0; i < numQueuedUpdatesToHandle; i++) {
-            this.queuedUpdates[i].reject(error);
-          }
+        const rejectHandledUpdates = (error: any) => {
+          handledUpdates.forEach(update => update.reject(error));
         };
-        const queuedUpdateTags = this.queuedUpdates.flatMap(update => update.tags);
-
+        const queuedUpdateTags = handledUpdates.flatMap(update => update.tags);
         const tag = Date.now() + "-" + Math.random();
 
         await new Promise<void>(nextStep => {
@@ -260,85 +249,83 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
           const unsubscribeArray: Array<() => void> = [];
           let settled = false;
 
-          const settle = () => {
+          /** Removes the handled batch before passive inner updates can resume. */
+          const finishWrite = (finishPromises: () => void, publishOuter: () => void) => {
             if (settled) {
               return;
             }
             settled = true;
-            this.isSubscriptionHandledByWriteLoop = false;
+            this.queuedUpdates.splice(0, numHandledUpdates);
             unsubscribeArray.forEach(unsubscribe => unsubscribe());
-            nextStep();
-          };
-          const flushQueuedTags = () => {
-            if (queuedUpdateTags.length > 0) {
-              this.setOuterSignal(
-                this.outerSignal.get() as StripNotAvailable<TData>,
-                queuedUpdateTags,
-              );
+            this.isSubscriptionHandledByWriteLoop = false;
+            finishPromises();
+            try {
+              publishOuter();
+            } finally {
+              nextStep();
             }
           };
+
+          /** Publishes a dropped write from fresh data, or keeps the outer value stale. */
+          const publishDroppedWrite = () => {
+            if (this.innerSignal.isStale()) {
+              this.markOuterStale(queuedUpdateTags);
+            } else {
+              this.updateOptimisticValue(this.setFreshOuterSignal, queuedUpdateTags);
+            }
+          };
+
           unsubscribeArray.push(
             this.innerSignal.subscribeFull((_data, _patches, tags) => {
-              if (!this.isSubscriptionHandledByWriteLoop) {
+              if (settled || !this.isSubscriptionHandledByWriteLoop) {
                 return;
               }
-              if (tags?.includes(tag)) {
-                settle();
-                resolve();
-                // If this update is caused by the write, we need to remove the optimistic update
-                // and apply the remaining optimistic updates
-                this.queuedUpdates.splice(0, numQueuedUpdatesToHandle);
-                this.updateOptimisticValue(
-                  tags.filter(t => t !== tag),
-                  true,
-                );
+              if (this.innerSignal.isStale()) {
+                this.markOuterStale(tags.filter(currentTag => currentTag !== tag));
+              } else if (tags.includes(tag)) {
+                finishWrite(resolveHandledUpdates, () => {
+                  this.updateOptimisticValue(
+                    this.setFreshOuterSignal,
+                    tags.filter(currentTag => currentTag !== tag),
+                  );
+                });
               } else {
-                // This update is not caused by the write, simply update the optimistic value
-                // as normal
-                this.updateOptimisticValue(tags, true);
+                this.updateOptimisticValue(this.setFreshOuterSignal, tags);
               }
             }),
           );
           unsubscribeArray.push(
             this.writeErrorEvent.subscribe(({ tags, error }) => {
-              if (!this.isSubscriptionHandledByWriteLoop) {
-                return;
-              }
-              if (tags.includes(tag)) {
-                flushQueuedTags();
-                settle();
-                reject(error);
-                this.queuedUpdates.splice(0, numQueuedUpdatesToHandle);
+              if (!settled && tags.includes(tag)) {
+                finishWrite(() => rejectHandledUpdates(error), publishDroppedWrite);
               }
             }),
           );
-
-          // Listen for transport-level errors on the inner signal
-          // This handles the case where the transport fails during an in-flight write
           unsubscribeArray.push(
             this.innerSignal.errorSignal.subscribe(error => {
-              // Only act if we're still waiting (not settled yet) and an error occurred
-              if (error !== null && !settled && this.isSubscriptionHandledByWriteLoop) {
-                flushQueuedTags();
-                settle();
-                reject(error);
-                this.queuedUpdates.splice(0, numQueuedUpdatesToHandle);
+              if (error !== null && !settled) {
+                finishWrite(
+                  () => rejectHandledUpdates(error),
+                  () => {
+                    this.markOuterStale(queuedUpdateTags);
+                  },
+                );
               }
             }),
           );
 
-          // At this point, we know the data is available, because upon entering the write loop, we
-          // ensure that the data is available by pulling. Hence, we can safely cast the data to
-          // StripNotAvailable<TData>.
-          const sent = this.writeUpstream(
-            ...updater(this.innerSignal.get() as StripNotAvailable<TData>),
-            [tag, ...queuedUpdateTags],
-          );
-          if (!sent) {
-            settle();
-            resolve();
-            this.queuedUpdates.splice(0, numQueuedUpdatesToHandle);
-            this.updateOptimisticValue(queuedUpdateTags.filter(t => t !== tag));
+          let sent: boolean;
+          try {
+            sent = this.writeUpstream(
+              ...updater(this.innerSignal.get() as StripNotAvailable<TData>),
+              [tag, ...queuedUpdateTags],
+            );
+          } catch (error) {
+            finishWrite(() => rejectHandledUpdates(error), publishDroppedWrite);
+            return;
+          }
+          if (!sent && !settled) {
+            finishWrite(resolveHandledUpdates, publishDroppedWrite);
           }
         });
       }
@@ -365,7 +352,7 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
    * {@link OWLSignal#pull}.
    */
   public isStale() {
-    return this.innerSignal.isStale();
+    return this.staleSignal.get();
   }
 
   /**
@@ -459,16 +446,5 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
       unsubscribeOuter();
       unsubscribeInner();
     };
-  }
-
-  /**
-   * Distinguishes optimistic updates made while stale from updates based on a fresh inner value.
-   */
-  public subscribeFullWithFreshness(
-    subscriber: SignalFullSubscriberWithFreshness<TData>,
-  ): () => void {
-    return this.subscribeFull((value, patches, tags) => {
-      subscriber(value, patches, tags, this.outerUpdateIsFresh ?? !this.isStale());
-    });
   }
 }

--- a/packages/lms-common/src/OWLSignal.ts
+++ b/packages/lms-common/src/OWLSignal.ts
@@ -99,6 +99,7 @@ export class OWLSignal<TData> extends Subscribable<TData> implements SignalLike<
     this.setOuterSignal(this.applyOptimisticUpdates(innerValue), tags);
   }
 
+  /** Creates the optimistic wrapper around its lazy upstream signal. */
   private constructor(
     initialValue: TData,
     subscribeUpstream: SubscribeUpstream<TData>,

--- a/packages/lms-common/src/Signal.test.ts
+++ b/packages/lms-common/src/Signal.test.ts
@@ -152,4 +152,60 @@ describe("Signal", () => {
     setSignal(0, ["tag1"]);
     expect(subscriber).toHaveBeenCalledWith(0, [{ op: "replace", path: [], value: 0 }], ["tag1"]);
   });
+
+  test("should commit a fresh value before notifying value and stale subscribers", () => {
+    const state = Signal.createWithStaleState(0, true);
+    const events: Array<string> = [];
+    state.signal.subscribe(value => {
+      events.push(`value:${value}:${state.signal.get()}:${state.signal.staleSignal?.get()}`);
+    });
+    state.signal.staleSignal?.subscribe(isStale => {
+      events.push(`stale:${isStale}:${state.signal.get()}`);
+    });
+
+    state.setFreshValue(1);
+
+    expect(events).toEqual(["value:1:1:false", "stale:false:1"]);
+  });
+
+  test("should notify value subscribers when an equal value restores freshness", () => {
+    const state = Signal.createWithStaleState(1, true);
+    const subscriber = jest.fn();
+    state.signal.subscribe(subscriber);
+
+    state.setFreshValue(1);
+
+    expect(subscriber).toHaveBeenCalledWith(1);
+    expect(state.signal.staleSignal?.get()).toBe(false);
+  });
+
+  test("should keep stale acknowledgement tags in the stale transaction", () => {
+    const state = Signal.createWithStaleState(0, false);
+    const callbackFull = jest.fn((_value, _patches, tags) => {
+      if (tags.includes("stale-tag")) {
+        expect(state.signal.staleSignal?.get()).toBe(true);
+        state.setFreshValue(1);
+      }
+    });
+    state.signal.subscribeFull(callbackFull);
+
+    state.markStale(["stale-tag"]);
+
+    expect(callbackFull).toHaveBeenNthCalledWith(1, 0, [], ["stale-tag"]);
+    expect(callbackFull).toHaveBeenNthCalledWith(2, 1, [{ op: "replace", path: [], value: 1 }], []);
+    expect(state.signal.staleSignal?.get()).toBe(false);
+  });
+
+  test("should not expose an uncommitted custom-equal candidate", () => {
+    const state = Signal.createWithStaleState({ id: 1, label: "old" }, true, (left, right) => {
+      return left.id === right.id;
+    });
+    const callbackFull = jest.fn();
+    state.signal.subscribeFull(callbackFull);
+
+    state.setFreshValue({ id: 1, label: "new" }, ["fresh-tag"]);
+
+    expect(state.signal.get()).toEqual({ id: 1, label: "old" });
+    expect(callbackFull).toHaveBeenCalledWith({ id: 1, label: "old" }, [], ["fresh-tag"]);
+  });
 });

--- a/packages/lms-common/src/Signal.ts
+++ b/packages/lms-common/src/Signal.ts
@@ -215,6 +215,8 @@ export class Signal<TValue> extends Subscribable<TValue> implements SignalLike<T
 }
 
 export interface SignalLike<TValue> extends Subscribable<TValue> {
+  /** Present when the signal can report whether its cached value is stale. */
+  readonly staleSignal?: Signal<boolean>;
   get(): TValue;
   subscribe(subscriber: Subscriber<TValue>): () => void;
   subscribeFull(subscriber: SignalFullSubscriber<TValue>): () => void;

--- a/packages/lms-common/src/Signal.ts
+++ b/packages/lms-common/src/Signal.ts
@@ -15,6 +15,14 @@ export type SignalFullSubscriber<TValue> = (
   tags: Array<WriteTag>,
 ) => void;
 
+/** Receives a full update and whether that update is based on fresh source data. */
+export type SignalFullSubscriberWithFreshness<TValue> = (
+  value: TValue,
+  patches: Array<Patch>,
+  tags: Array<WriteTag>,
+  isFresh: boolean,
+) => void;
+
 type InternalSubscriber<TValue> =
   | {
       type: "regular";
@@ -220,6 +228,11 @@ export interface SignalLike<TValue> extends Subscribable<TValue> {
   get(): TValue;
   subscribe(subscriber: Subscriber<TValue>): () => void;
   subscribeFull(subscriber: SignalFullSubscriber<TValue>): () => void;
+  /**
+   * Reports freshness on the value update itself, before a later staleSignal notification. Signals
+   * that can emit local updates while stale should implement this method.
+   */
+  subscribeFullWithFreshness?(subscriber: SignalFullSubscriberWithFreshness<TValue>): () => void;
   pull(): Promise<StripNotAvailable<TValue>> | StripNotAvailable<TValue>;
 }
 

--- a/packages/lms-common/src/Signal.ts
+++ b/packages/lms-common/src/Signal.ts
@@ -15,14 +15,6 @@ export type SignalFullSubscriber<TValue> = (
   tags: Array<WriteTag>,
 ) => void;
 
-/** Receives a full update and whether that update is based on fresh source data. */
-export type SignalFullSubscriberWithFreshness<TValue> = (
-  value: TValue,
-  patches: Array<Patch>,
-  tags: Array<WriteTag>,
-  isFresh: boolean,
-) => void;
-
 type InternalSubscriber<TValue> =
   | {
       type: "regular";
@@ -32,6 +24,12 @@ type InternalSubscriber<TValue> =
       type: "full";
       callback: SignalFullSubscriber<TValue>;
     };
+
+interface QueuedUpdate<TValue> {
+  updater: Updater<TValue>;
+  tags?: Array<WriteTag>;
+  nextStale?: boolean;
+}
 
 /**
  * A signal is a wrapper for a value. It can be used to notify subscribers when the value changes.
@@ -57,33 +55,67 @@ export class Signal<TValue> extends Subscribable<TValue> implements SignalLike<T
     equalsPredicate: (a: TValue, b: TValue) => boolean = equals,
   ): readonly [Signal<TValue>, Setter<TValue>] {
     const signal = new Signal(value, equalsPredicate);
-    const update = (updater: Updater<TValue>, tags?: Array<WriteTag>) => {
+    const setter = makeSetterWithPatches<TValue>((updater, tags) => {
       signal.update(updater, tags);
-    };
-    const setter = makeSetterWithPatches(update);
+    });
     return [signal, setter] as const;
   }
+
+  /**
+   * Creates a signal whose value and stale state are committed by the same update queue.
+   *
+   * The preserving setter leaves freshness unchanged. The fresh setter restores freshness with its
+   * value, and markStale can carry acknowledgement tags without changing the value.
+   */
+  public static createWithStaleState<TValue>(
+    value: TValue,
+    initialStale: boolean,
+    equalsPredicate: (a: TValue, b: TValue) => boolean = equals,
+  ) {
+    const signal = new Signal(value, equalsPredicate, initialStale);
+    const setValue = makeSetterWithPatches<TValue>((updater, tags) => {
+      signal.update(updater, tags);
+    });
+    const setFreshValue = makeSetterWithPatches<TValue>((updater, tags) => {
+      signal.update(updater, tags, false);
+    });
+    const markStale = (tags?: Array<WriteTag>) => {
+      signal.update(value => [value, []], tags, true);
+    };
+    return { signal, setValue, setFreshValue, markStale };
+  }
+
   public static createReadonly<TValue>(value: TValue): Signal<TValue> {
     return Signal.create(value)[0];
   }
+
   protected constructor(
     private value: TValue,
     private equalsPredicate: (a: TValue, b: TValue) => boolean,
+    initialStale?: boolean,
   ) {
     super();
+    if (initialStale !== undefined) {
+      this.staleSignal = new Signal<boolean>(initialStale, equals);
+    }
   }
+
   private subscribers: Set<InternalSubscriber<TValue>> = new Set();
-  /**
-   * Returns the current value of the signal.
-   */
+  /** Present for signals that track value freshness. */
+  public readonly staleSignal?: Signal<boolean>;
+
+  /** Returns the current value. */
   public get() {
     return this.value;
   }
+
   public pull() {
     return this.value as StripNotAvailable<TValue>;
   }
-  private queuedUpdaters: Array<[updater: Updater<TValue>, tags?: Array<WriteTag>]> = [];
+
+  private queuedUpdates: Array<QueuedUpdate<TValue>> = [];
   private isEmitting = false;
+
   private notifyFull(value: TValue, patches: Array<Patch>, tags: Array<WriteTag>) {
     for (const { type, callback } of this.subscribers) {
       if (type === "full") {
@@ -91,6 +123,7 @@ export class Signal<TValue> extends Subscribable<TValue> implements SignalLike<T
       }
     }
   }
+
   private notifyAll(value: TValue, patches: Array<Patch>, tags: Array<WriteTag>) {
     for (const { type, callback } of this.subscribers) {
       if (type === "regular") {
@@ -100,52 +133,65 @@ export class Signal<TValue> extends Subscribable<TValue> implements SignalLike<T
       }
     }
   }
-  private notifyAndUpdateIfChanged(value: TValue, patches: Array<Patch>, tags: Array<WriteTag>) {
-    // If the value has changed, or if there are any tags that need to be flushed, notify
-    if (!this.equalsPredicate(this.value, value)) {
-      this.value = value;
-      // If the values have changed, notify everyone
-      this.notifyAll(value, patches, tags);
-    } else if (tags.length > 0) {
-      // If values not changed, but there is a tag to be flushed, notify only full subscribers
-      this.notifyFull(value, patches, tags);
-    }
-  }
 
   private isReplaceRoot(patch: Patch) {
     return patch.path.length === 0 && patch.op === "replace";
   }
 
-  private update(updater: Updater<TValue>, tags?: Array<WriteTag>) {
-    this.queuedUpdaters.push([updater, tags]);
-    // Only one concurrent update may emit
+  /** Queues one value/freshness operation and emits only fully committed state. */
+  private update(updater: Updater<TValue>, tags?: Array<WriteTag>, nextStale?: boolean) {
+    this.queuedUpdates.push({ updater, tags, nextStale });
     if (this.isEmitting) {
       return;
     }
     this.isEmitting = true;
     try {
-      // Outer while is for handling new updates caused by the notify
-      while (this.queuedUpdaters.length > 0) {
+      while (this.queuedUpdates.length > 0) {
         let value = this.value;
+        let stale = this.staleSignal?.get();
+        const previousStale = stale;
         let patches: Array<Patch> = [];
         const tags: Array<WriteTag> = [];
-        // Inner while is for handling multiple updates
-        while (this.queuedUpdaters.length > 0) {
-          const [updater, newTags] = this.queuedUpdaters.shift()!;
-          const [newValue, newPatches] = updater(value);
+
+        while (this.queuedUpdates.length > 0) {
+          const update = this.queuedUpdates.shift()!;
+          const [newValue, newPatches] = update.updater(value);
           value = newValue;
-          // Extremely rudimentary patch merging
           const rootReplacerIndex = newPatches.findIndex(this.isReplaceRoot);
           if (rootReplacerIndex !== -1) {
             patches = newPatches.slice(rootReplacerIndex);
           } else {
             patches.push(...newPatches);
           }
-          if (newTags !== undefined) {
-            tags.push(...newTags);
+          if (update.tags !== undefined) {
+            tags.push(...update.tags);
+          }
+          if (update.nextStale !== undefined) {
+            stale = update.nextStale;
           }
         }
-        this.notifyAndUpdateIfChanged(value, patches, tags);
+
+        const valueChanged = !this.equalsPredicate(this.value, value);
+        const staleChanged = previousStale !== stale;
+        const becameFresh = previousStale === true && stale === false;
+        if (valueChanged) {
+          this.value = value;
+        } else if (value !== this.value) {
+          // A custom equality predicate kept the old value, so candidate patches were not applied.
+          patches = [];
+        }
+        if (staleChanged) {
+          this.staleSignal!.value = stale!;
+        }
+
+        if (valueChanged || becameFresh) {
+          this.notifyAll(this.value, patches, tags);
+        } else if (tags.length > 0) {
+          this.notifyFull(this.value, patches, tags);
+        }
+        if (staleChanged) {
+          this.staleSignal!.notifyAll(stale!, [{ op: "replace", path: [], value: stale }], []);
+        }
       }
     } finally {
       this.isEmitting = false;
@@ -163,7 +209,7 @@ export class Signal<TValue> extends Subscribable<TValue> implements SignalLike<T
    * - If the callback causes removal of subscribers that have not been called yet, they will no
    *   longer be called.
    * - If the callback causes an update of the value, the update will be queued. If multiple updates
-   *   are queued, only the last one will be executed.
+   *   are queued, only the final combined value will be emitted.
    *
    * Edge cases involving adding the same callback multiple times.
    *
@@ -181,10 +227,7 @@ export class Signal<TValue> extends Subscribable<TValue> implements SignalLike<T
     };
   }
 
-  /**
-   * Subscribes to the signal with the callback and trigger the callback immediately with the
-   * current value.
-   */
+  /** Subscribes and immediately calls the callback with the current value. */
   public subscribeAndNow(callback: Subscriber<TValue>): () => void {
     const unsubscribe = this.subscribe(callback);
     callback(this.value);
@@ -202,10 +245,7 @@ export class Signal<TValue> extends Subscribable<TValue> implements SignalLike<T
     };
   }
 
-  /**
-   * Wait until the signal satisfies a predicate. If the predicate is already satisfied, it will
-   * return immediately. Otherwise, it will wait until the signal satisfies the predicate.
-   */
+  /** Waits until the signal satisfies a predicate. */
   public async until(predicate: (data: TValue) => boolean): Promise<TValue> {
     const current = this.get();
     if (predicate(current)) {
@@ -223,16 +263,14 @@ export class Signal<TValue> extends Subscribable<TValue> implements SignalLike<T
 }
 
 export interface SignalLike<TValue> extends Subscribable<TValue> {
-  /** Present when the signal can report whether its cached value is stale. */
+  /**
+   * Present when the signal can report whether its cached value is stale. A stale-to-fresh
+   * transition must also emit one value event, even when the committed value compares equal.
+   */
   readonly staleSignal?: Signal<boolean>;
   get(): TValue;
   subscribe(subscriber: Subscriber<TValue>): () => void;
   subscribeFull(subscriber: SignalFullSubscriber<TValue>): () => void;
-  /**
-   * Reports freshness on the value update itself, before a later staleSignal notification. Signals
-   * that can emit local updates while stale should implement this method.
-   */
-  subscribeFullWithFreshness?(subscriber: SignalFullSubscriberWithFreshness<TValue>): () => void;
   pull(): Promise<StripNotAvailable<TValue>> | StripNotAvailable<TValue>;
 }
 

--- a/packages/lms-common/src/SlicedSignal.test.ts
+++ b/packages/lms-common/src/SlicedSignal.test.ts
@@ -369,6 +369,55 @@ describe("SlicedSignal", () => {
     unsubscribe();
   });
 
+  it("should preserve sliced patches and tags from a recovery update", () => {
+    const sourceValue = { a: { b: { c: 1 } } };
+    let emitUpstream!: Setter<typeof sourceValue>;
+    let failUpstream: (error: Error) => void = () => {};
+    const sourceSignal = LazySignal.create(sourceValue, (setDownstream, errorListener) => {
+      emitUpstream = setDownstream;
+      failUpstream = errorListener;
+      return () => {};
+    });
+    const sourceSetterUpdate = jest.fn();
+    const sourceSetter = makeSetterWithPatches<typeof sourceValue>(sourceSetterUpdate);
+    const [slicedSignal, setSliced] = makeSlicedSignalFrom([sourceSignal, sourceSetter])
+      .access("a")
+      .access("b")
+      .done();
+    const callbackFull = jest.fn();
+    const unsubscribe = slicedSignal.subscribeFull(callbackFull);
+
+    emitUpstream(sourceValue);
+    callbackFull.mockClear();
+    failUpstream(new Error("source failed"));
+
+    setSliced.withProducer(
+      draft => {
+        draft.c = 2;
+      },
+      ["fresh-tag"],
+    );
+    const [updater, tags] = sourceSetterUpdate.mock.calls[0];
+    expect(sourceSignal.recoverFromError()).toBe(true);
+    emitUpstream.withPatchUpdater(updater, tags);
+
+    expect(callbackFull).toHaveBeenCalledWith(
+      { c: 2 },
+      [{ op: "replace", path: ["c"], value: 2 }],
+      ["fresh-tag"],
+    );
+
+    callbackFull.mockClear();
+    failUpstream(new Error("source failed again"));
+    setSliced.withValueAndPatches({ c: 2 }, [], ["ack-tag"]);
+    const [tagOnlyUpdater, tagOnlyTags] = sourceSetterUpdate.mock.calls[1];
+    expect(sourceSignal.recoverFromError()).toBe(true);
+    emitUpstream.withPatchUpdater(tagOnlyUpdater, tagOnlyTags);
+
+    expect(callbackFull).toHaveBeenCalledWith({ c: 2 }, [], ["ack-tag"]);
+    unsubscribe();
+  });
+
   it("should be able to read with regular signal with arrays", () => {
     const [sourceSignal, setSource] = Signal.create({ a: [{ b: { c: 1 } }, { d: { e: 2 } }] });
     const [slicedSignal, _setSliced] = makeSlicedSignalFrom([sourceSignal, setSource])

--- a/packages/lms-common/src/SlicedSignal.test.ts
+++ b/packages/lms-common/src/SlicedSignal.test.ts
@@ -1,6 +1,6 @@
 import "."; // Import order
 
-import { LazySignal, makeSetterWithPatches, NotAvailable, Setter } from ".";
+import { LazySignal, makeSetterWithPatches, NotAvailable, OWLSignal, Setter } from ".";
 import { Signal } from "./Signal.js";
 import {
   chainMaybeShortCircuitedSignalFrom,
@@ -366,6 +366,38 @@ describe("SlicedSignal", () => {
 
     await expect(pullPromise).resolves.toEqual({ c: 1 });
     expect(slicedSignal.isStale()).toBe(false);
+    unsubscribe();
+  });
+
+  it("should remain stale when a stale OWLSignal emits an optimistic update", async () => {
+    const sourceValue = { a: { b: { c: 1 } } };
+    let emitUpstream!: Setter<typeof sourceValue>;
+    const sourceWritableSignal = OWLSignal.create(
+      sourceValue,
+      setDownstream => {
+        emitUpstream = setDownstream;
+        return () => {};
+      },
+      () => false,
+    );
+    const [slicedSignal] = makeSlicedSignalFrom(sourceWritableSignal)
+      .access("a")
+      .access("b")
+      .done();
+    const callback = jest.fn();
+    const unsubscribe = slicedSignal.subscribe(callback);
+
+    sourceWritableSignal[1].withProducer(draft => {
+      draft.a.b.c = 2;
+    });
+
+    expect(sourceWritableSignal[0].isStale()).toBe(true);
+    expect(slicedSignal.isStale()).toBe(true);
+    expect(slicedSignal.get()).toEqual({ c: 1 });
+    expect(callback).not.toHaveBeenCalled();
+
+    emitUpstream(sourceValue);
+    await new Promise(resolve => setTimeout(resolve, 0));
     unsubscribe();
   });
 

--- a/packages/lms-common/src/SlicedSignal.test.ts
+++ b/packages/lms-common/src/SlicedSignal.test.ts
@@ -372,7 +372,7 @@ describe("SlicedSignal", () => {
   it("should remain stale when a stale OWLSignal emits an optimistic update", async () => {
     const sourceValue = { a: { b: { c: 1 } } };
     let emitUpstream!: Setter<typeof sourceValue>;
-    const sourceWritableSignal = OWLSignal.create(
+    const [sourceSignal, setSourceSignal] = OWLSignal.create(
       sourceValue,
       setDownstream => {
         emitUpstream = setDownstream;
@@ -380,18 +380,18 @@ describe("SlicedSignal", () => {
       },
       () => false,
     );
-    const [slicedSignal] = makeSlicedSignalFrom(sourceWritableSignal)
+    const [slicedSignal] = makeSlicedSignalFrom([sourceSignal, setSourceSignal])
       .access("a")
       .access("b")
       .done();
     const callback = jest.fn();
     const unsubscribe = slicedSignal.subscribe(callback);
 
-    sourceWritableSignal[1].withProducer(draft => {
+    setSourceSignal.withProducer(draft => {
       draft.a.b.c = 2;
     });
 
-    expect(sourceWritableSignal[0].isStale()).toBe(true);
+    expect(sourceSignal.isStale()).toBe(true);
     expect(slicedSignal.isStale()).toBe(true);
     expect(slicedSignal.get()).toEqual({ c: 1 });
     expect(callback).not.toHaveBeenCalled();

--- a/packages/lms-common/src/SlicedSignal.test.ts
+++ b/packages/lms-common/src/SlicedSignal.test.ts
@@ -401,6 +401,67 @@ describe("SlicedSignal", () => {
     unsubscribe();
   });
 
+  it("should forward stale OWLSignal tags without forwarding its optimistic value", () => {
+    const sourceValue = { a: { b: { c: 1 } } };
+    let emitUpstream!: Setter<typeof sourceValue>;
+    let failUpstream: (error: Error) => void = () => {};
+    const [sourceSignal, setSourceSignal] = OWLSignal.create(
+      sourceValue,
+      (setDownstream, errorListener) => {
+        emitUpstream = setDownstream;
+        failUpstream = errorListener;
+        return () => {};
+      },
+      () => true,
+    );
+    const [slicedSignal, setSliced] = makeSlicedSignalFrom([sourceSignal, setSourceSignal])
+      .access("a")
+      .access("b")
+      .done();
+    const callbackFull = jest.fn();
+    const unsubscribe = slicedSignal.subscribeFull(callbackFull);
+
+    emitUpstream(sourceValue);
+    callbackFull.mockClear();
+    failUpstream(new Error("transport failed"));
+    setSliced.withValueAndPatches({ c: 1 }, [], ["dropped-write"]);
+
+    expect(sourceSignal.isStale()).toBe(true);
+    expect(slicedSignal.isStale()).toBe(true);
+    expect(slicedSignal.get()).toEqual({ c: 1 });
+    expect(callbackFull).toHaveBeenCalledWith({ c: 1 }, [], ["dropped-write"]);
+    unsubscribe();
+  });
+
+  it("should become fresh when recovery patches do not affect the slice", async () => {
+    const sourceValue = { a: { b: { c: 1 } }, outside: 0 };
+    let emitUpstream!: Setter<typeof sourceValue>;
+    let failUpstream: (error: Error) => void = () => {};
+    const sourceSignal = LazySignal.create(sourceValue, (setDownstream, errorListener) => {
+      emitUpstream = setDownstream;
+      failUpstream = errorListener;
+      return () => {};
+    });
+    const sourceSetter = makeSetterWithPatches<typeof sourceValue>(() => {});
+    const [slicedSignal] = makeSlicedSignalFrom([sourceSignal, sourceSetter])
+      .access("a")
+      .access("b")
+      .done();
+    const unsubscribe = slicedSignal.subscribe(() => {});
+
+    emitUpstream(sourceValue);
+    failUpstream(new Error("source failed"));
+    const pullPromise = slicedSignal.pull();
+    expect(sourceSignal.recoverFromError()).toBe(true);
+    emitUpstream.withProducer(draft => {
+      draft.outside = 1;
+    });
+
+    await expect(pullPromise).resolves.toEqual({ c: 1 });
+    expect(slicedSignal.isStale()).toBe(false);
+    unsubscribe();
+  });
+
   it("should preserve sliced patches and tags from a recovery update", () => {
     const sourceValue = { a: { b: { c: 1 } } };
     let emitUpstream!: Setter<typeof sourceValue>;

--- a/packages/lms-common/src/SlicedSignal.test.ts
+++ b/packages/lms-common/src/SlicedSignal.test.ts
@@ -337,6 +337,38 @@ describe("SlicedSignal", () => {
     );
   });
 
+  it("should become stale while its lazy source recovers", async () => {
+    const sourceValue = { a: { b: { c: 1 } } };
+    let emitUpstream: (value: typeof sourceValue) => void = () => {};
+    let failUpstream: (error: Error) => void = () => {};
+    const sourceSignal = LazySignal.create(sourceValue, (setDownstream, errorListener) => {
+      emitUpstream = setDownstream;
+      failUpstream = errorListener;
+      return () => {};
+    });
+    const sourceSetter = makeSetterWithPatches<typeof sourceValue>(() => {});
+    const [slicedSignal] = makeSlicedSignalFrom([sourceSignal, sourceSetter])
+      .access("a")
+      .access("b")
+      .done();
+    const unsubscribe = slicedSignal.subscribe(() => {});
+
+    emitUpstream(sourceValue);
+    expect(slicedSignal.isStale()).toBe(false);
+
+    failUpstream(new Error("source failed"));
+    expect(slicedSignal.isStale()).toBe(true);
+
+    const pullPromise = slicedSignal.pull();
+    expect(sourceSignal.recoverFromError()).toBe(true);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    emitUpstream(sourceValue);
+
+    await expect(pullPromise).resolves.toEqual({ c: 1 });
+    expect(slicedSignal.isStale()).toBe(false);
+    unsubscribe();
+  });
+
   it("should be able to read with regular signal with arrays", () => {
     const [sourceSignal, setSource] = Signal.create({ a: [{ b: { c: 1 } }, { d: { e: 2 } }] });
     const [slicedSignal, _setSliced] = makeSlicedSignalFrom([sourceSignal, setSource])

--- a/packages/lms-common/src/SlicedSignal.ts
+++ b/packages/lms-common/src/SlicedSignal.ts
@@ -275,6 +275,7 @@ class SlicedSignalBuilderImpl<
     this.path.push(key);
     return this as any;
   }
+  /** Builds a writable signal for the selected path. */
   public done(): readonly [
     signal: LazySignal<
       | TCurrent
@@ -293,8 +294,26 @@ class SlicedSignalBuilderImpl<
       | TCurrent
       | (TCanBeNotAvailable extends true ? NotAvailable : never)
       | (TCanBeShortCircuited extends true ? ShortCircuited : never)
-    >(initialValue, setDownstream => {
+    >(initialValue, (setDownstream, _errorListener, markDownstreamStale) => {
+      /** Replaces the slice after its source becomes fresh. */
+      const updateFromCurrentSource = () => {
+        if (this.sourceSignal.staleSignal?.get() === true) {
+          markDownstreamStale();
+          return;
+        }
+        const value = this.sourceSignal.get();
+        if (!isAvailable(value)) {
+          markDownstreamStale();
+        } else {
+          setDownstream(isShortCircuited(value) ? value : drill(value, this.accessPath));
+        }
+      };
+
       const unsubscribe = this.sourceSignal.subscribeFull((value, patches, tags) => {
+        if (this.sourceSignal.staleSignal?.get() === true) {
+          markDownstreamStale();
+          return;
+        }
         const newPatches: Array<Patch> = [];
         // Transform patches
         for (const patch of patches) {
@@ -350,16 +369,19 @@ class SlicedSignalBuilderImpl<
           setDownstream.withValueAndPatches(newValue, newPatches, newTags);
         }
       });
-      const value = this.sourceSignal.pull();
-      if (value instanceof Promise) {
-        value.then(value => {
-          setDownstream(drill(value, this.accessPath));
-        });
-      } else {
-        setDownstream(drill(value, this.accessPath));
-      }
+      const unsubscribeStaleSignal = this.sourceSignal.staleSignal?.subscribe(isStale => {
+        if (isStale) {
+          markDownstreamStale();
+        } else {
+          updateFromCurrentSource();
+        }
+      });
+      updateFromCurrentSource();
 
-      return unsubscribe;
+      return () => {
+        unsubscribeStaleSignal?.();
+        unsubscribe();
+      };
     });
     const setter = makeSetterWithPatches<TCurrent>((updater, tags) => {
       const newTags = tags?.map(tag => this.tagKey + tag);

--- a/packages/lms-common/src/SlicedSignal.ts
+++ b/packages/lms-common/src/SlicedSignal.ts
@@ -5,7 +5,7 @@ import {
   type NotAvailable,
   type StripNotAvailable,
 } from "./LazySignal.js";
-import { makeSetterWithPatches, type Setter } from "./makeSetter.js";
+import { makeSetterWithPatches, type Setter, type WriteTag } from "./makeSetter.js";
 import { type SignalLike } from "./Signal.js";
 
 type PathSegment =
@@ -309,9 +309,17 @@ class SlicedSignalBuilderImpl<
         }
       };
 
-      const unsubscribe = this.sourceSignal.subscribeFull((value, patches, tags) => {
-        // This update restores source freshness after recovery. Handle it before staleSignal changes
-        // so its patches and tags reach the sliced signal.
+      /** Applies source metadata only when the source says this particular update is fresh. */
+      const updateFromSource = (
+        value: TSource | ShortCircuited,
+        patches: Array<Patch>,
+        tags: Array<WriteTag>,
+        isFresh = this.sourceSignal.staleSignal?.get() !== true,
+      ) => {
+        if (!isFresh) {
+          markDownstreamStale();
+          return;
+        }
         const newPatches: Array<Patch> = [];
         // Transform patches
         for (const patch of patches) {
@@ -366,7 +374,10 @@ class SlicedSignalBuilderImpl<
         if (newPatches.length > 0 || newTags.length > 0) {
           setDownstream.withValueAndPatches(newValue, newPatches, newTags);
         }
-      });
+      };
+      const unsubscribe =
+        this.sourceSignal.subscribeFullWithFreshness?.(updateFromSource) ??
+        this.sourceSignal.subscribeFull(updateFromSource);
       const unsubscribeStaleSignal = this.sourceSignal.staleSignal?.subscribe(isStale => {
         if (isStale) {
           markDownstreamStale();

--- a/packages/lms-common/src/SlicedSignal.ts
+++ b/packages/lms-common/src/SlicedSignal.ts
@@ -310,10 +310,8 @@ class SlicedSignalBuilderImpl<
       };
 
       const unsubscribe = this.sourceSignal.subscribeFull((value, patches, tags) => {
-        if (this.sourceSignal.staleSignal?.get() === true) {
-          markDownstreamStale();
-          return;
-        }
+        // This update restores source freshness after recovery. Handle it before staleSignal changes
+        // so its patches and tags reach the sliced signal.
         const newPatches: Array<Patch> = [];
         // Transform patches
         for (const patch of patches) {

--- a/packages/lms-common/src/SlicedSignal.ts
+++ b/packages/lms-common/src/SlicedSignal.ts
@@ -309,15 +309,17 @@ class SlicedSignalBuilderImpl<
         }
       };
 
-      /** Applies source metadata only when the source says this particular update is fresh. */
+      /** Applies fresh source metadata and forwards only acknowledgements while stale. */
       const updateFromSource = (
         value: TSource | ShortCircuited,
         patches: Array<Patch>,
         tags: Array<WriteTag>,
-        isFresh = this.sourceSignal.staleSignal?.get() !== true,
       ) => {
-        if (!isFresh) {
-          markDownstreamStale();
+        const newTags = tags
+          .filter(tag => tag.startsWith(this.tagKey))
+          .map(tag => tag.slice(this.tagKey.length));
+        if (this.sourceSignal.staleSignal?.get() === true) {
+          markDownstreamStale(newTags);
           return;
         }
         const newPatches: Array<Patch> = [];
@@ -368,21 +370,12 @@ class SlicedSignalBuilderImpl<
           // Otherwise, we don't need to do anything
         }
         const newValue = isShortCircuited(value) ? value : drill(value, this.accessPath);
-        const newTags = tags
-          .filter(tag => tag.startsWith(this.tagKey))
-          .map(tag => tag.slice(this.tagKey.length));
-        if (newPatches.length > 0 || newTags.length > 0) {
-          setDownstream.withValueAndPatches(newValue, newPatches, newTags);
-        }
+        setDownstream.withValueAndPatches(newValue, newPatches, newTags);
       };
-      const unsubscribe =
-        this.sourceSignal.subscribeFullWithFreshness?.(updateFromSource) ??
-        this.sourceSignal.subscribeFull(updateFromSource);
+      const unsubscribe = this.sourceSignal.subscribeFull(updateFromSource);
       const unsubscribeStaleSignal = this.sourceSignal.staleSignal?.subscribe(isStale => {
         if (isStale) {
           markDownstreamStale();
-        } else {
-          updateFromCurrentSource();
         }
       });
       updateFromCurrentSource();

--- a/packages/lms-common/src/flattenSignal.test.ts
+++ b/packages/lms-common/src/flattenSignal.test.ts
@@ -266,6 +266,76 @@ describe("flattenSignalOfSignal", () => {
     unsubscribe();
   });
 
+  it("should apply a fresh reentrant OWLSignal update after a stale optimistic update", async () => {
+    const initialValue = { count: 0 };
+    let emitUpstream!: Setter<typeof initialValue>;
+    let writeTags: Array<string> = [];
+    const [innerSignal, setInnerSignal] = OWLSignal.create(
+      initialValue,
+      setDownstream => {
+        emitUpstream = setDownstream;
+        return () => {};
+      },
+      (_value, _patches, tags) => {
+        writeTags = tags;
+        return true;
+      },
+    );
+    const unsubscribeReentrantUpdate = innerSignal.subscribe(value => {
+      if (value.count === 1) {
+        emitUpstream({ count: 10 });
+      }
+    });
+    const flattenedSignal = flattenSignalOfSignal(Signal.createReadonly(innerSignal));
+    const callback = jest.fn();
+    const unsubscribe = flattenedSignal.subscribe(callback);
+
+    setInnerSignal.withProducer(draft => {
+      draft.count += 1;
+    });
+
+    expect(innerSignal.isStale()).toBe(false);
+    expect(innerSignal.get()).toEqual({ count: 11 });
+    expect(flattenedSignal.isStale()).toBe(false);
+    expect(flattenedSignal.get()).toEqual({ count: 11 });
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith({ count: 11 });
+
+    emitUpstream.withValueAndPatches({ count: 11 }, [], writeTags);
+    await waitForTick();
+    unsubscribe();
+    unsubscribeReentrantUpdate();
+  });
+
+  it("should forward stale OWLSignal tags without forwarding its optimistic value", () => {
+    const initialValue = { count: 0 };
+    let emitUpstream!: Setter<typeof initialValue>;
+    let failUpstream: (error: Error) => void = () => {};
+    const [innerSignal, setInnerSignal] = OWLSignal.create(
+      initialValue,
+      (setDownstream, errorListener) => {
+        emitUpstream = setDownstream;
+        failUpstream = errorListener;
+        return () => {};
+      },
+      () => true,
+    );
+    const flattenedSignal = flattenSignalOfSignal(Signal.createReadonly(innerSignal));
+    const callbackFull = jest.fn();
+    const unsubscribe = flattenedSignal.subscribeFull(callbackFull);
+
+    emitUpstream(initialValue);
+    callbackFull.mockClear();
+    failUpstream(new Error("transport failed"));
+    setInnerSignal(initialValue, ["dropped-write"]);
+
+    expect(innerSignal.isStale()).toBe(true);
+    expect(flattenedSignal.isStale()).toBe(true);
+    expect(flattenedSignal.get()).toEqual(initialValue);
+    expect(callbackFull).toHaveBeenCalledWith(initialValue, [], ["dropped-write"]);
+    unsubscribe();
+  });
+
   it("should become stale while its inner signal recovers", async () => {
     let emitInnerSignal: (value: string) => void = () => {};
     let failInnerSignal: (error: Error) => void = () => {};

--- a/packages/lms-common/src/flattenSignal.test.ts
+++ b/packages/lms-common/src/flattenSignal.test.ts
@@ -1,6 +1,7 @@
 import { flattenSignalOfSignal, flattenSignalOfWritableSignal } from "./flattenSignal.js";
 import { LazySignal } from "./LazySignal.js";
 import { type Setter } from "./makeSetter.js";
+import { OWLSignal } from "./OWLSignal.js";
 import { Signal } from "./Signal.js";
 
 async function waitForTick(): Promise<void> {
@@ -227,6 +228,36 @@ describe("flattenSignalOfSignal", () => {
     await expect(pullPromise).resolves.toBe("fresh");
   });
 
+  it("should remain stale when a stale OWLSignal emits an optimistic update", async () => {
+    const initialValue = { count: 0 };
+    let emitUpstream!: Setter<typeof initialValue>;
+    const [innerSignal, setInnerSignal] = OWLSignal.create(
+      initialValue,
+      setDownstream => {
+        emitUpstream = setDownstream;
+        return () => {};
+      },
+      () => false,
+    );
+    const outerSignal = Signal.createReadonly(innerSignal);
+    const flattenedSignal = flattenSignalOfSignal(outerSignal);
+    const callback = jest.fn();
+    const unsubscribe = flattenedSignal.subscribe(callback);
+
+    setInnerSignal.withProducer(draft => {
+      draft.count = 1;
+    });
+
+    expect(innerSignal.isStale()).toBe(true);
+    expect(flattenedSignal.isStale()).toBe(true);
+    expect(flattenedSignal.get()).toEqual(initialValue);
+    expect(callback).not.toHaveBeenCalled();
+
+    emitUpstream(initialValue);
+    await waitForTick();
+    unsubscribe();
+  });
+
   it("should become stale while its inner signal recovers", async () => {
     let emitInnerSignal: (value: string) => void = () => {};
     let failInnerSignal: (error: Error) => void = () => {};
@@ -406,6 +437,36 @@ describe("flattenSignalOfWritableSignal", () => {
 
     emitInnerSignal("fresh");
     await expect(pullPromise).resolves.toBe("fresh");
+  });
+
+  it("should remain stale when a stale inner OWLSignal emits an optimistic update", async () => {
+    const initialValue = { count: 0 };
+    let emitUpstream!: Setter<typeof initialValue>;
+    const innerWritableSignal = OWLSignal.create(
+      initialValue,
+      setDownstream => {
+        emitUpstream = setDownstream;
+        return () => {};
+      },
+      () => false,
+    );
+    const outerSignal = Signal.createReadonly(innerWritableSignal);
+    const [flattenedSignal] = flattenSignalOfWritableSignal(outerSignal);
+    const callback = jest.fn();
+    const unsubscribe = flattenedSignal.subscribe(callback);
+
+    innerWritableSignal[1].withProducer(draft => {
+      draft.count = 1;
+    });
+
+    expect(innerWritableSignal[0].isStale()).toBe(true);
+    expect(flattenedSignal.isStale()).toBe(true);
+    expect(flattenedSignal.get()).toEqual(initialValue);
+    expect(callback).not.toHaveBeenCalled();
+
+    emitUpstream(initialValue);
+    await waitForTick();
+    unsubscribe();
   });
 
   it("should become stale while its inner writable signal recovers", async () => {

--- a/packages/lms-common/src/flattenSignal.test.ts
+++ b/packages/lms-common/src/flattenSignal.test.ts
@@ -177,6 +177,34 @@ describe("flattenSignalOfSignal", () => {
     await expect(pullPromise).resolves.toBe("fresh");
   });
 
+  it("should become stale while its root signal recovers", async () => {
+    const innerSignal = Signal.createReadonly("value");
+    let emitRootSignal: (value: typeof innerSignal) => void = () => {};
+    let failRootSignal: (error: Error) => void = () => {};
+    const rootSignal = LazySignal.create(innerSignal, (setDownstream, errorListener) => {
+      emitRootSignal = setDownstream;
+      failRootSignal = errorListener;
+      return () => {};
+    });
+    const flattenedSignal = flattenSignalOfSignal(rootSignal);
+    const unsubscribe = flattenedSignal.subscribe(() => {});
+
+    emitRootSignal(innerSignal);
+    expect(flattenedSignal.isStale()).toBe(false);
+
+    failRootSignal(new Error("root failed"));
+    expect(flattenedSignal.isStale()).toBe(true);
+
+    const pullPromise = flattenedSignal.pull();
+    expect(rootSignal.recoverFromError()).toBe(true);
+    await waitForTick();
+    emitRootSignal(innerSignal);
+
+    await expect(pullPromise).resolves.toBe("value");
+    expect(flattenedSignal.isStale()).toBe(false);
+    unsubscribe();
+  });
+
   it("should not treat a stale inner signal's cached value as fresh", async () => {
     let emitInnerSignal: (value: string) => void = () => {};
     const innerSignal = LazySignal.create("cached", setDownstream => {
@@ -197,6 +225,34 @@ describe("flattenSignalOfSignal", () => {
 
     emitInnerSignal("fresh");
     await expect(pullPromise).resolves.toBe("fresh");
+  });
+
+  it("should become stale while its inner signal recovers", async () => {
+    let emitInnerSignal: (value: string) => void = () => {};
+    let failInnerSignal: (error: Error) => void = () => {};
+    const innerSignal = LazySignal.create("cached", (setDownstream, errorListener) => {
+      emitInnerSignal = setDownstream;
+      failInnerSignal = errorListener;
+      return () => {};
+    });
+    const outerSignal = Signal.createReadonly(innerSignal);
+    const flattenedSignal = flattenSignalOfSignal(outerSignal);
+    const unsubscribe = flattenedSignal.subscribe(() => {});
+
+    emitInnerSignal("fresh");
+    expect(flattenedSignal.isStale()).toBe(false);
+
+    failInnerSignal(new Error("inner failed"));
+    expect(flattenedSignal.isStale()).toBe(true);
+
+    const pullPromise = flattenedSignal.pull();
+    expect(innerSignal.recoverFromError()).toBe(true);
+    await waitForTick();
+    emitInnerSignal("fresh");
+
+    await expect(pullPromise).resolves.toBe("fresh");
+    expect(flattenedSignal.isStale()).toBe(false);
+    unsubscribe();
   });
 
   it("should accept a same-value snapshot from a stale inner signal as fresh", async () => {
@@ -291,6 +347,35 @@ describe("flattenSignalOfWritableSignal", () => {
 
     emitInnerSignal("fresh");
     await expect(pullPromise).resolves.toBe("fresh");
+  });
+
+  it("should become stale while its inner writable signal recovers", async () => {
+    let emitInnerSignal: (value: string) => void = () => {};
+    let failInnerSignal: (error: Error) => void = () => {};
+    const innerSignal = LazySignal.create("cached", (setDownstream, errorListener) => {
+      emitInnerSignal = setDownstream;
+      failInnerSignal = errorListener;
+      return () => {};
+    });
+    const [, unusedSetter] = Signal.create("unused");
+    const outerSignal = Signal.createReadonly([innerSignal, unusedSetter] as const);
+    const [flattenedSignal] = flattenSignalOfWritableSignal(outerSignal);
+    const unsubscribe = flattenedSignal.subscribe(() => {});
+
+    emitInnerSignal("fresh");
+    expect(flattenedSignal.isStale()).toBe(false);
+
+    failInnerSignal(new Error("inner failed"));
+    expect(flattenedSignal.isStale()).toBe(true);
+
+    const pullPromise = flattenedSignal.pull();
+    expect(innerSignal.recoverFromError()).toBe(true);
+    await waitForTick();
+    emitInnerSignal("fresh");
+
+    await expect(pullPromise).resolves.toBe("fresh");
+    expect(flattenedSignal.isStale()).toBe(false);
+    unsubscribe();
   });
 
   it("should accept a same-value snapshot from a stale inner writable signal as fresh", async () => {

--- a/packages/lms-common/src/flattenSignal.test.ts
+++ b/packages/lms-common/src/flattenSignal.test.ts
@@ -255,6 +255,65 @@ describe("flattenSignalOfSignal", () => {
     unsubscribe();
   });
 
+  it("should preserve patches and tags from an inner recovery update", () => {
+    const initialValue = { nested: { count: 0 } };
+    let emitInnerSignal!: Setter<typeof initialValue>;
+    let failInnerSignal: (error: Error) => void = () => {};
+    const innerSignal = LazySignal.create(initialValue, (setDownstream, errorListener) => {
+      emitInnerSignal = setDownstream;
+      failInnerSignal = errorListener;
+      return () => {};
+    });
+    const outerSignal = Signal.createReadonly(innerSignal);
+    const flattenedSignal = flattenSignalOfSignal(outerSignal);
+    const callbackFull = jest.fn();
+    const unsubscribe = flattenedSignal.subscribeFull(callbackFull);
+
+    emitInnerSignal(initialValue);
+    callbackFull.mockClear();
+    failInnerSignal(new Error("inner failed"));
+    expect(innerSignal.recoverFromError()).toBe(true);
+
+    emitInnerSignal.withProducer(
+      draft => {
+        draft.nested.count = 1;
+      },
+      ["fresh-tag"],
+    );
+
+    expect(callbackFull).toHaveBeenCalledWith(
+      { nested: { count: 1 } },
+      [{ op: "replace", path: ["nested", "count"], value: 1 }],
+      ["fresh-tag"],
+    );
+    unsubscribe();
+  });
+
+  it("should preserve a tag-only inner recovery update", () => {
+    const initialValue = { nested: { count: 0 } };
+    let emitInnerSignal!: Setter<typeof initialValue>;
+    let failInnerSignal: (error: Error) => void = () => {};
+    const innerSignal = LazySignal.create(initialValue, (setDownstream, errorListener) => {
+      emitInnerSignal = setDownstream;
+      failInnerSignal = errorListener;
+      return () => {};
+    });
+    const outerSignal = Signal.createReadonly(innerSignal);
+    const flattenedSignal = flattenSignalOfSignal(outerSignal);
+    const callbackFull = jest.fn();
+    const unsubscribe = flattenedSignal.subscribeFull(callbackFull);
+
+    emitInnerSignal(initialValue);
+    callbackFull.mockClear();
+    failInnerSignal(new Error("inner failed"));
+    expect(innerSignal.recoverFromError()).toBe(true);
+
+    emitInnerSignal.withValueAndPatches(initialValue, [], ["fresh-tag"]);
+
+    expect(callbackFull).toHaveBeenCalledWith(initialValue, [], ["fresh-tag"]);
+    unsubscribe();
+  });
+
   it("should accept a same-value snapshot from a stale inner signal as fresh", async () => {
     let emitInnerSignal: (value: string) => void = () => {};
     const innerSignal = LazySignal.create("cached", setDownstream => {
@@ -375,6 +434,67 @@ describe("flattenSignalOfWritableSignal", () => {
 
     await expect(pullPromise).resolves.toBe("fresh");
     expect(flattenedSignal.isStale()).toBe(false);
+    unsubscribe();
+  });
+
+  it("should preserve patches and tags from an inner writable recovery update", () => {
+    const initialValue = { nested: { count: 0 } };
+    let emitInnerSignal!: Setter<typeof initialValue>;
+    let failInnerSignal: (error: Error) => void = () => {};
+    const innerSignal = LazySignal.create(initialValue, (setDownstream, errorListener) => {
+      emitInnerSignal = setDownstream;
+      failInnerSignal = errorListener;
+      return () => {};
+    });
+    const [, unusedSetter] = Signal.create(initialValue);
+    const outerSignal = Signal.createReadonly([innerSignal, unusedSetter] as const);
+    const [flattenedSignal] = flattenSignalOfWritableSignal(outerSignal);
+    const callbackFull = jest.fn();
+    const unsubscribe = flattenedSignal.subscribeFull(callbackFull);
+
+    emitInnerSignal(initialValue);
+    callbackFull.mockClear();
+    failInnerSignal(new Error("inner failed"));
+    expect(innerSignal.recoverFromError()).toBe(true);
+
+    emitInnerSignal.withProducer(
+      draft => {
+        draft.nested.count = 1;
+      },
+      ["fresh-tag"],
+    );
+
+    expect(callbackFull).toHaveBeenCalledWith(
+      { nested: { count: 1 } },
+      [{ op: "replace", path: ["nested", "count"], value: 1 }],
+      ["fresh-tag"],
+    );
+    unsubscribe();
+  });
+
+  it("should preserve a tag-only inner writable recovery update", () => {
+    const initialValue = { nested: { count: 0 } };
+    let emitInnerSignal!: Setter<typeof initialValue>;
+    let failInnerSignal: (error: Error) => void = () => {};
+    const innerSignal = LazySignal.create(initialValue, (setDownstream, errorListener) => {
+      emitInnerSignal = setDownstream;
+      failInnerSignal = errorListener;
+      return () => {};
+    });
+    const [, unusedSetter] = Signal.create(initialValue);
+    const outerSignal = Signal.createReadonly([innerSignal, unusedSetter] as const);
+    const [flattenedSignal] = flattenSignalOfWritableSignal(outerSignal);
+    const callbackFull = jest.fn();
+    const unsubscribe = flattenedSignal.subscribeFull(callbackFull);
+
+    emitInnerSignal(initialValue);
+    callbackFull.mockClear();
+    failInnerSignal(new Error("inner failed"));
+    expect(innerSignal.recoverFromError()).toBe(true);
+
+    emitInnerSignal.withValueAndPatches(initialValue, [], ["fresh-tag"]);
+
+    expect(callbackFull).toHaveBeenCalledWith(initialValue, [], ["fresh-tag"]);
     unsubscribe();
   });
 

--- a/packages/lms-common/src/flattenSignal.test.ts
+++ b/packages/lms-common/src/flattenSignal.test.ts
@@ -547,6 +547,36 @@ describe("flattenSignalOfWritableSignal", () => {
     unsubscribe();
   });
 
+  it("should forward stale inner OWLSignal tags without forwarding its value", () => {
+    const initialValue = { count: 0 };
+    let emitUpstream!: Setter<typeof initialValue>;
+    let failUpstream: (error: Error) => void = () => {};
+    const [innerSignal, setInnerSignal] = OWLSignal.create(
+      initialValue,
+      (setDownstream, errorListener) => {
+        emitUpstream = setDownstream;
+        failUpstream = errorListener;
+        return () => {};
+      },
+      () => true,
+    );
+    const outerSignal = Signal.createReadonly([innerSignal, setInnerSignal] as const);
+    const [flattenedSignal] = flattenSignalOfWritableSignal(outerSignal);
+    const callbackFull = jest.fn();
+    const unsubscribe = flattenedSignal.subscribeFull(callbackFull);
+
+    emitUpstream(initialValue);
+    callbackFull.mockClear();
+    failUpstream(new Error("transport failed"));
+    setInnerSignal(initialValue, ["dropped-write"]);
+
+    expect(innerSignal.isStale()).toBe(true);
+    expect(flattenedSignal.isStale()).toBe(true);
+    expect(flattenedSignal.get()).toEqual(initialValue);
+    expect(callbackFull).toHaveBeenCalledWith(initialValue, [], ["dropped-write"]);
+    unsubscribe();
+  });
+
   it("should become stale while its inner writable signal recovers", async () => {
     let emitInnerSignal: (value: string) => void = () => {};
     let failInnerSignal: (error: Error) => void = () => {};

--- a/packages/lms-common/src/flattenSignal.test.ts
+++ b/packages/lms-common/src/flattenSignal.test.ts
@@ -250,11 +250,19 @@ describe("flattenSignalOfSignal", () => {
 
     expect(innerSignal.isStale()).toBe(true);
     expect(flattenedSignal.isStale()).toBe(true);
-    expect(flattenedSignal.get()).toEqual(initialValue);
+    expect(flattenedSignal.get()).toBe(LazySignal.NOT_AVAILABLE);
     expect(callback).not.toHaveBeenCalled();
 
+    const pullPromise = flattenedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await Promise.resolve();
+    expect(pullResolved).toBe(false);
+
     emitUpstream(initialValue);
-    await waitForTick();
+    await expect(pullPromise).resolves.toEqual({ count: 1 });
     unsubscribe();
   });
 
@@ -442,7 +450,7 @@ describe("flattenSignalOfWritableSignal", () => {
   it("should remain stale when a stale inner OWLSignal emits an optimistic update", async () => {
     const initialValue = { count: 0 };
     let emitUpstream!: Setter<typeof initialValue>;
-    const innerWritableSignal = OWLSignal.create(
+    const [innerSignal, setInnerSignal] = OWLSignal.create(
       initialValue,
       setDownstream => {
         emitUpstream = setDownstream;
@@ -450,18 +458,18 @@ describe("flattenSignalOfWritableSignal", () => {
       },
       () => false,
     );
-    const outerSignal = Signal.createReadonly(innerWritableSignal);
+    const outerSignal = Signal.createReadonly([innerSignal, setInnerSignal] as const);
     const [flattenedSignal] = flattenSignalOfWritableSignal(outerSignal);
     const callback = jest.fn();
     const unsubscribe = flattenedSignal.subscribe(callback);
 
-    innerWritableSignal[1].withProducer(draft => {
+    setInnerSignal.withProducer(draft => {
       draft.count = 1;
     });
 
-    expect(innerWritableSignal[0].isStale()).toBe(true);
+    expect(innerSignal.isStale()).toBe(true);
     expect(flattenedSignal.isStale()).toBe(true);
-    expect(flattenedSignal.get()).toEqual(initialValue);
+    expect(flattenedSignal.get()).toBe(LazySignal.NOT_AVAILABLE);
     expect(callback).not.toHaveBeenCalled();
 
     emitUpstream(initialValue);

--- a/packages/lms-common/src/flattenSignal.test.ts
+++ b/packages/lms-common/src/flattenSignal.test.ts
@@ -153,9 +153,169 @@ describe("flattenSignalOfSignal", () => {
     await expect(pullPromise).resolves.toBe(7);
     expect(flattenedSignal.get()).toBe(7);
   });
+
+  it("should not treat a stale root signal's cached inner signal as fresh", async () => {
+    const cachedInnerSignal = Signal.createReadonly("cached");
+    const freshInnerSignal = Signal.createReadonly("fresh");
+    let emitRootSignal: (value: typeof cachedInnerSignal) => void = () => {};
+    const rootSignal = LazySignal.create(cachedInnerSignal, setDownstream => {
+      emitRootSignal = setDownstream;
+      return () => {};
+    });
+    const flattenedSignal = flattenSignalOfSignal(rootSignal);
+
+    const pullPromise = flattenedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await waitForTick();
+
+    expect(pullResolved).toBe(false);
+
+    emitRootSignal(freshInnerSignal);
+    await expect(pullPromise).resolves.toBe("fresh");
+  });
+
+  it("should not treat a stale inner signal's cached value as fresh", async () => {
+    let emitInnerSignal: (value: string) => void = () => {};
+    const innerSignal = LazySignal.create("cached", setDownstream => {
+      emitInnerSignal = setDownstream;
+      return () => {};
+    });
+    const outerSignal = Signal.createReadonly(innerSignal);
+    const flattenedSignal = flattenSignalOfSignal(outerSignal);
+
+    const pullPromise = flattenedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await waitForTick();
+
+    expect(pullResolved).toBe(false);
+
+    emitInnerSignal("fresh");
+    await expect(pullPromise).resolves.toBe("fresh");
+  });
+
+  it("should accept a same-value snapshot from a stale inner signal as fresh", async () => {
+    let emitInnerSignal: (value: string) => void = () => {};
+    const innerSignal = LazySignal.create("cached", setDownstream => {
+      emitInnerSignal = setDownstream;
+      return () => {};
+    });
+    const outerSignal = Signal.createReadonly(innerSignal);
+    const flattenedSignal = flattenSignalOfSignal(outerSignal);
+
+    const pullPromise = flattenedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await waitForTick();
+
+    expect(pullResolved).toBe(false);
+
+    emitInnerSignal("cached");
+    await expect(pullPromise).resolves.toBe("cached");
+  });
+
+  it("should stop waiting for a stale inner signal after switching inner signals", async () => {
+    let emitStaleInnerSignal: (value: string) => void = () => {};
+    const unsubscribeStaleInnerSignal = jest.fn();
+    const staleInnerSignal = LazySignal.create("stale-cached", setDownstream => {
+      emitStaleInnerSignal = setDownstream;
+      return unsubscribeStaleInnerSignal;
+    });
+    const freshInnerSignal = Signal.createReadonly("fresh");
+    const [outerSignal, setOuterSignal] = Signal.create<
+      typeof staleInnerSignal | typeof freshInnerSignal
+    >(staleInnerSignal);
+    const flattenedSignal = flattenSignalOfSignal(outerSignal);
+
+    const pullPromise = flattenedSignal.pull();
+    await waitForTick();
+
+    setOuterSignal(freshInnerSignal);
+    await expect(pullPromise).resolves.toBe("fresh");
+    expect(unsubscribeStaleInnerSignal).toHaveBeenCalledTimes(1);
+
+    emitStaleInnerSignal("late");
+    expect(flattenedSignal.get()).toBe("fresh");
+  });
 });
 
 describe("flattenSignalOfWritableSignal", () => {
+  it("should not treat a stale root signal's cached writable signal as fresh", async () => {
+    const cachedInnerWritableSignal = Signal.create("cached");
+    const freshInnerWritableSignal = Signal.create("fresh");
+    let emitRootSignal: (value: typeof cachedInnerWritableSignal) => void = () => {};
+    const rootSignal = LazySignal.create(cachedInnerWritableSignal, setDownstream => {
+      emitRootSignal = setDownstream;
+      return () => {};
+    });
+    const [flattenedSignal] = flattenSignalOfWritableSignal(rootSignal);
+
+    const pullPromise = flattenedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await waitForTick();
+
+    expect(pullResolved).toBe(false);
+
+    emitRootSignal(freshInnerWritableSignal);
+    await expect(pullPromise).resolves.toBe("fresh");
+  });
+
+  it("should not treat a stale inner writable signal's cached value as fresh", async () => {
+    let emitInnerSignal: (value: string) => void = () => {};
+    const innerSignal = LazySignal.create("cached", setDownstream => {
+      emitInnerSignal = setDownstream;
+      return () => {};
+    });
+    const [, unusedSetter] = Signal.create("unused");
+    const outerSignal = Signal.createReadonly([innerSignal, unusedSetter] as const);
+    const [flattenedSignal] = flattenSignalOfWritableSignal(outerSignal);
+
+    const pullPromise = flattenedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await waitForTick();
+
+    expect(pullResolved).toBe(false);
+
+    emitInnerSignal("fresh");
+    await expect(pullPromise).resolves.toBe("fresh");
+  });
+
+  it("should accept a same-value snapshot from a stale inner writable signal as fresh", async () => {
+    let emitInnerSignal: (value: string) => void = () => {};
+    const innerSignal = LazySignal.create("cached", setDownstream => {
+      emitInnerSignal = setDownstream;
+      return () => {};
+    });
+    const [, unusedSetter] = Signal.create("unused");
+    const outerSignal = Signal.createReadonly([innerSignal, unusedSetter] as const);
+    const [flattenedSignal] = flattenSignalOfWritableSignal(outerSignal);
+
+    const pullPromise = flattenedSignal.pull();
+    let pullResolved = false;
+    void pullPromise.then(() => {
+      pullResolved = true;
+    });
+    await waitForTick();
+
+    expect(pullResolved).toBe(false);
+
+    emitInnerSignal("cached");
+    await expect(pullPromise).resolves.toBe("cached");
+  });
+
   it("should preserve nested patches and tags from a stable inner writable signal", async () => {
     const innerWritableSignal = Signal.create({
       nested: {

--- a/packages/lms-common/src/flattenSignal.ts
+++ b/packages/lms-common/src/flattenSignal.ts
@@ -46,9 +46,10 @@ export function flattenSignalOfSignal<TInner>(
           patches?: Array<Patch>,
           tags?: Array<WriteTag>,
         ) => {
+          // Full updates restore inner freshness and include patches, while get() snapshots do not.
           if (
             rootSignal.staleSignal?.get() === true ||
-            maybeInnerSignal.staleSignal?.get() === true
+            (patches === undefined && maybeInnerSignal.staleSignal?.get() === true)
           ) {
             markDownstreamStale();
             return;
@@ -158,9 +159,10 @@ export function flattenSignalOfWritableSignal<TInner>(
           patches?: Array<Patch>,
           tags?: Array<WriteTag>,
         ) => {
+          // Full updates restore inner freshness and include patches, while get() snapshots do not.
           if (
             rootSignal.staleSignal?.get() === true ||
-            maybeInnerSignal[0].staleSignal?.get() === true ||
+            (patches === undefined && maybeInnerSignal[0].staleSignal?.get() === true) ||
             !isAvailable(value)
           ) {
             innerSetter = null;

--- a/packages/lms-common/src/flattenSignal.ts
+++ b/packages/lms-common/src/flattenSignal.ts
@@ -20,33 +20,56 @@ export function flattenSignalOfSignal<TInner>(
 ): LazySignal<TInner | NotAvailable> {
   return LazySignal.createWithoutInitialValue<TInner>(setDownstream => {
     let unsubscribeInnerSignal: (() => void) | null = null;
+    let cancelInnerFreshnessWait: (() => void) | null = null;
     const subscribeToInnerSignal = (
       maybeInnerSignal: SignalLike<TInner | NotAvailable> | NotAvailable,
     ) => {
       if (!isAvailable(maybeInnerSignal)) {
-        return () => {};
+        return;
       }
-      if (unsubscribeInnerSignal !== null) {
-        unsubscribeInnerSignal();
-        unsubscribeInnerSignal = null;
-      }
+      cancelInnerFreshnessWait?.();
+      cancelInnerFreshnessWait = null;
+      unsubscribeInnerSignal?.();
+      let updateReceived = false;
       unsubscribeInnerSignal = maybeInnerSignal.subscribeFull((value, patches, tags) => {
+        updateReceived = true;
         if (!isAvailable(value)) {
           return;
         }
         setDownstream.withValueAndPatches(value, patches, tags);
       });
-      const currentValue = maybeInnerSignal.get();
-      if (isAvailable(currentValue)) {
-        setDownstream(currentValue);
+      if (LazySignal.isLazySignal(maybeInnerSignal) && maybeInnerSignal.isStale()) {
+        cancelInnerFreshnessWait = maybeInnerSignal.runOnNextFreshData(value => {
+          if (!updateReceived && isAvailable(value)) {
+            setDownstream(value);
+          }
+        });
+      } else {
+        const currentValue = maybeInnerSignal.get();
+        if (isAvailable(currentValue)) {
+          setDownstream(currentValue);
+        }
       }
     };
-    const unsubscribeRootSignal = rootSignal.subscribe(subscribeToInnerSignal);
-    subscribeToInnerSignal(rootSignal.get());
+    let rootUpdateReceived = false;
+    const unsubscribeRootSignal = rootSignal.subscribe(value => {
+      rootUpdateReceived = true;
+      subscribeToInnerSignal(value);
+    });
+    let cancelRootFreshnessWait: (() => void) | null = null;
+    if (LazySignal.isLazySignal(rootSignal) && rootSignal.isStale()) {
+      cancelRootFreshnessWait = rootSignal.runOnNextFreshData(value => {
+        if (!rootUpdateReceived) {
+          subscribeToInnerSignal(value);
+        }
+      });
+    } else {
+      subscribeToInnerSignal(rootSignal.get());
+    }
     return () => {
-      if (unsubscribeInnerSignal !== null) {
-        unsubscribeInnerSignal();
-      }
+      cancelInnerFreshnessWait?.();
+      unsubscribeInnerSignal?.();
+      cancelRootFreshnessWait?.();
       unsubscribeRootSignal();
     };
   });
@@ -80,18 +103,19 @@ export function flattenSignalOfWritableSignal<TInner>(
   });
   signal = LazySignal.createWithoutInitialValue<TInner>(setDownstream => {
     let unsubscribeInnerSignal: (() => void) | null = null;
+    let cancelInnerFreshnessWait: (() => void) | null = null;
     const subscribeToInnerSignal = (
       maybeInnerSignal:
         | readonly [signal: SignalLike<TInner | NotAvailable>, setter: Setter<TInner>]
         | NotAvailable,
     ) => {
       if (!isAvailable(maybeInnerSignal)) {
-        return () => {};
+        return;
       }
-      if (unsubscribeInnerSignal !== null) {
-        unsubscribeInnerSignal();
-        unsubscribeInnerSignal = null;
-      }
+      cancelInnerFreshnessWait?.();
+      cancelInnerFreshnessWait = null;
+      unsubscribeInnerSignal?.();
+      innerSetter = null;
       const maybeUpdateDownstream = (
         value: TInner | NotAvailable,
         patches?: Array<Patch>,
@@ -135,16 +159,41 @@ export function flattenSignalOfWritableSignal<TInner>(
         }
         innerSetter = setter;
       };
-      unsubscribeInnerSignal = maybeInnerSignal[0].subscribeFull(maybeUpdateDownstream);
-      maybeUpdateDownstream(maybeInnerSignal[0].get());
-    };
-    const unsubscribeRootSignal = rootSignal.subscribe(subscribeToInnerSignal);
-    subscribeToInnerSignal(rootSignal.get());
-    return () => {
-      if (unsubscribeInnerSignal !== null) {
-        unsubscribeInnerSignal();
+      let updateReceived = false;
+      unsubscribeInnerSignal = maybeInnerSignal[0].subscribeFull((value, patches, tags) => {
+        updateReceived = true;
+        maybeUpdateDownstream(value, patches, tags);
+      });
+      if (LazySignal.isLazySignal(maybeInnerSignal[0]) && maybeInnerSignal[0].isStale()) {
+        cancelInnerFreshnessWait = maybeInnerSignal[0].runOnNextFreshData(value => {
+          if (!updateReceived) {
+            maybeUpdateDownstream(value);
+          }
+        });
+      } else {
+        maybeUpdateDownstream(maybeInnerSignal[0].get());
       }
+    };
+    let rootUpdateReceived = false;
+    const unsubscribeRootSignal = rootSignal.subscribe(value => {
+      rootUpdateReceived = true;
+      subscribeToInnerSignal(value);
+    });
+    let cancelRootFreshnessWait: (() => void) | null = null;
+    if (LazySignal.isLazySignal(rootSignal) && rootSignal.isStale()) {
+      cancelRootFreshnessWait = rootSignal.runOnNextFreshData(value => {
+        if (!rootUpdateReceived) {
+          subscribeToInnerSignal(value);
+        }
+      });
+    } else {
+      subscribeToInnerSignal(rootSignal.get());
+    }
+    return () => {
+      cancelInnerFreshnessWait?.();
+      unsubscribeInnerSignal?.();
       innerSetter = null;
+      cancelRootFreshnessWait?.();
       unsubscribeRootSignal();
     };
   });

--- a/packages/lms-common/src/flattenSignal.ts
+++ b/packages/lms-common/src/flattenSignal.ts
@@ -18,61 +18,87 @@ function isReplaceRootPatch(patch: Patch): boolean {
 export function flattenSignalOfSignal<TInner>(
   rootSignal: SignalLike<SignalLike<TInner | NotAvailable> | NotAvailable>,
 ): LazySignal<TInner | NotAvailable> {
-  return LazySignal.createWithoutInitialValue<TInner>(setDownstream => {
-    let unsubscribeInnerSignal: (() => void) | null = null;
-    let cancelInnerFreshnessWait: (() => void) | null = null;
-    const subscribeToInnerSignal = (
-      maybeInnerSignal: SignalLike<TInner | NotAvailable> | NotAvailable,
-    ) => {
-      if (!isAvailable(maybeInnerSignal)) {
-        return;
-      }
-      cancelInnerFreshnessWait?.();
-      cancelInnerFreshnessWait = null;
-      unsubscribeInnerSignal?.();
-      let updateReceived = false;
-      unsubscribeInnerSignal = maybeInnerSignal.subscribeFull((value, patches, tags) => {
-        updateReceived = true;
-        if (!isAvailable(value)) {
+  return LazySignal.createWithoutInitialValue<TInner>(
+    (setDownstream, _errorListener, markDownstreamStale) => {
+      let unsubscribeInnerSignal: (() => void) | null = null;
+      let unsubscribeInnerStaleSignal: (() => void) | null = null;
+
+      /** Stops listening to the previously selected inner signal. */
+      const unsubscribeInner = () => {
+        unsubscribeInnerStaleSignal?.();
+        unsubscribeInnerStaleSignal = null;
+        unsubscribeInnerSignal?.();
+        unsubscribeInnerSignal = null;
+      };
+
+      /** Selects the current inner signal once both levels are fresh. */
+      const subscribeToInnerSignal = (
+        maybeInnerSignal: SignalLike<TInner | NotAvailable> | NotAvailable,
+      ) => {
+        unsubscribeInner();
+        if (!isAvailable(maybeInnerSignal)) {
+          markDownstreamStale();
           return;
         }
-        setDownstream.withValueAndPatches(value, patches, tags);
-      });
-      if (LazySignal.isLazySignal(maybeInnerSignal) && maybeInnerSignal.isStale()) {
-        cancelInnerFreshnessWait = maybeInnerSignal.runOnNextFreshData(value => {
-          if (!updateReceived && isAvailable(value)) {
-            setDownstream(value);
+
+        const updateFromInner = (
+          value: TInner | NotAvailable,
+          patches?: Array<Patch>,
+          tags?: Array<WriteTag>,
+        ) => {
+          if (
+            rootSignal.staleSignal?.get() === true ||
+            maybeInnerSignal.staleSignal?.get() === true
+          ) {
+            markDownstreamStale();
+            return;
           }
-        });
-      } else {
-        const currentValue = maybeInnerSignal.get();
-        if (isAvailable(currentValue)) {
-          setDownstream(currentValue);
+          if (!isAvailable(value)) {
+            markDownstreamStale();
+          } else if (patches === undefined) {
+            setDownstream(value, tags);
+          } else {
+            setDownstream.withValueAndPatches(value, patches, tags);
+          }
+        };
+
+        unsubscribeInnerSignal = maybeInnerSignal.subscribeFull(updateFromInner);
+        unsubscribeInnerStaleSignal = maybeInnerSignal.staleSignal?.subscribe(isStale => {
+          if (isStale) {
+            markDownstreamStale();
+          } else {
+            updateFromInner(maybeInnerSignal.get());
+          }
+        }) ?? null;
+        updateFromInner(maybeInnerSignal.get());
+      };
+
+      /** Rechecks the root after value and freshness changes. */
+      const updateFromRoot = () => {
+        if (rootSignal.staleSignal?.get() === true) {
+          markDownstreamStale();
+        } else {
+          subscribeToInnerSignal(rootSignal.get());
         }
-      }
-    };
-    let rootUpdateReceived = false;
-    const unsubscribeRootSignal = rootSignal.subscribe(value => {
-      rootUpdateReceived = true;
-      subscribeToInnerSignal(value);
-    });
-    let cancelRootFreshnessWait: (() => void) | null = null;
-    if (LazySignal.isLazySignal(rootSignal) && rootSignal.isStale()) {
-      cancelRootFreshnessWait = rootSignal.runOnNextFreshData(value => {
-        if (!rootUpdateReceived) {
-          subscribeToInnerSignal(value);
+      };
+
+      const unsubscribeRootSignal = rootSignal.subscribe(updateFromRoot);
+      const unsubscribeRootStaleSignal = rootSignal.staleSignal?.subscribe(isStale => {
+        if (isStale) {
+          markDownstreamStale();
+        } else {
+          updateFromRoot();
         }
       });
-    } else {
-      subscribeToInnerSignal(rootSignal.get());
-    }
-    return () => {
-      cancelInnerFreshnessWait?.();
-      unsubscribeInnerSignal?.();
-      cancelRootFreshnessWait?.();
-      unsubscribeRootSignal();
-    };
-  });
+      updateFromRoot();
+
+      return () => {
+        unsubscribeInner();
+        unsubscribeRootStaleSignal?.();
+        unsubscribeRootSignal();
+      };
+    },
+  );
 }
 
 /**
@@ -101,101 +127,121 @@ export function flattenSignalOfWritableSignal<TInner>(
       signal.pull().catch(console.error);
     }
   });
-  signal = LazySignal.createWithoutInitialValue<TInner>(setDownstream => {
-    let unsubscribeInnerSignal: (() => void) | null = null;
-    let cancelInnerFreshnessWait: (() => void) | null = null;
-    const subscribeToInnerSignal = (
-      maybeInnerSignal:
-        | readonly [signal: SignalLike<TInner | NotAvailable>, setter: Setter<TInner>]
-        | NotAvailable,
-    ) => {
-      if (!isAvailable(maybeInnerSignal)) {
-        return;
-      }
-      cancelInnerFreshnessWait?.();
-      cancelInnerFreshnessWait = null;
-      unsubscribeInnerSignal?.();
-      innerSetter = null;
-      const maybeUpdateDownstream = (
-        value: TInner | NotAvailable,
-        patches?: Array<Patch>,
-        tags?: Array<WriteTag>,
+  signal = LazySignal.createWithoutInitialValue<TInner>(
+    (setDownstream, _errorListener, markDownstreamStale) => {
+      let unsubscribeInnerSignal: (() => void) | null = null;
+      let unsubscribeInnerStaleSignal: (() => void) | null = null;
+
+      /** Stops writes and updates from the previously selected inner signal. */
+      const unsubscribeInner = () => {
+        unsubscribeInnerStaleSignal?.();
+        unsubscribeInnerStaleSignal = null;
+        unsubscribeInnerSignal?.();
+        unsubscribeInnerSignal = null;
+        innerSetter = null;
+      };
+
+      /** Selects the current writable signal once both levels are fresh. */
+      const subscribeToInnerSignal = (
+        maybeInnerSignal:
+          | readonly [signal: SignalLike<TInner | NotAvailable>, setter: Setter<TInner>]
+          | NotAvailable,
       ) => {
-        if (!isAvailable(value)) {
+        unsubscribeInner();
+        if (!isAvailable(maybeInnerSignal)) {
+          markDownstreamStale();
           return;
         }
-        if (patches !== undefined) {
-          setDownstream.withValueAndPatches(value, patches, tags);
-        } else {
-          setDownstream(value, tags);
-        }
-        const setter = maybeInnerSignal[1];
 
-        // Apply queued updates
-        if (queuedUpdates.length !== 0) {
-          const updatesToApply = queuedUpdates;
-          queuedUpdates = [];
-          let currentValue: TInner = value;
-          let accumulatedPatches: Array<Patch> = [];
-          const tags: Array<WriteTag> = [];
-          for (const { updater, tags: newTags } of updatesToApply) {
-            const [newValue, newPatches] = updater(currentValue);
-            currentValue = newValue;
-            const rootReplacerIndex = newPatches.findIndex(isReplaceRootPatch);
-            if (rootReplacerIndex !== -1) {
-              accumulatedPatches = newPatches.slice(rootReplacerIndex);
-            } else {
-              accumulatedPatches.push(...newPatches);
-            }
-            if (newTags !== undefined) {
-              tags.push(...newTags);
-            }
+        const maybeUpdateDownstream = (
+          value: TInner | NotAvailable,
+          patches?: Array<Patch>,
+          tags?: Array<WriteTag>,
+        ) => {
+          if (
+            rootSignal.staleSignal?.get() === true ||
+            maybeInnerSignal[0].staleSignal?.get() === true ||
+            !isAvailable(value)
+          ) {
+            innerSetter = null;
+            markDownstreamStale();
+            return;
           }
-          setter.withValueAndPatches(
-            currentValue as StripNotAvailable<TInner>,
-            accumulatedPatches,
-            tags,
-          );
-        }
-        innerSetter = setter;
-      };
-      let updateReceived = false;
-      unsubscribeInnerSignal = maybeInnerSignal[0].subscribeFull((value, patches, tags) => {
-        updateReceived = true;
-        maybeUpdateDownstream(value, patches, tags);
-      });
-      if (LazySignal.isLazySignal(maybeInnerSignal[0]) && maybeInnerSignal[0].isStale()) {
-        cancelInnerFreshnessWait = maybeInnerSignal[0].runOnNextFreshData(value => {
-          if (!updateReceived) {
-            maybeUpdateDownstream(value);
+          if (patches !== undefined) {
+            setDownstream.withValueAndPatches(value, patches, tags);
+          } else {
+            setDownstream(value, tags);
           }
-        });
-      } else {
+          const setter = maybeInnerSignal[1];
+
+          // Apply writes that arrived while the selected signal was stale or unavailable.
+          if (queuedUpdates.length !== 0) {
+            const updatesToApply = queuedUpdates;
+            queuedUpdates = [];
+            let currentValue: TInner = value;
+            let accumulatedPatches: Array<Patch> = [];
+            const tags: Array<WriteTag> = [];
+            for (const { updater, tags: newTags } of updatesToApply) {
+              const [newValue, newPatches] = updater(currentValue);
+              currentValue = newValue;
+              const rootReplacerIndex = newPatches.findIndex(isReplaceRootPatch);
+              if (rootReplacerIndex !== -1) {
+                accumulatedPatches = newPatches.slice(rootReplacerIndex);
+              } else {
+                accumulatedPatches.push(...newPatches);
+              }
+              if (newTags !== undefined) {
+                tags.push(...newTags);
+              }
+            }
+            setter.withValueAndPatches(
+              currentValue as StripNotAvailable<TInner>,
+              accumulatedPatches,
+              tags,
+            );
+          }
+          innerSetter = setter;
+        };
+
+        unsubscribeInnerSignal = maybeInnerSignal[0].subscribeFull(maybeUpdateDownstream);
+        unsubscribeInnerStaleSignal = maybeInnerSignal[0].staleSignal?.subscribe(isStale => {
+          if (isStale) {
+            innerSetter = null;
+            markDownstreamStale();
+          } else {
+            maybeUpdateDownstream(maybeInnerSignal[0].get());
+          }
+        }) ?? null;
         maybeUpdateDownstream(maybeInnerSignal[0].get());
-      }
-    };
-    let rootUpdateReceived = false;
-    const unsubscribeRootSignal = rootSignal.subscribe(value => {
-      rootUpdateReceived = true;
-      subscribeToInnerSignal(value);
-    });
-    let cancelRootFreshnessWait: (() => void) | null = null;
-    if (LazySignal.isLazySignal(rootSignal) && rootSignal.isStale()) {
-      cancelRootFreshnessWait = rootSignal.runOnNextFreshData(value => {
-        if (!rootUpdateReceived) {
-          subscribeToInnerSignal(value);
+      };
+
+      /** Rechecks the root after value and freshness changes. */
+      const updateFromRoot = () => {
+        if (rootSignal.staleSignal?.get() === true) {
+          innerSetter = null;
+          markDownstreamStale();
+        } else {
+          subscribeToInnerSignal(rootSignal.get());
+        }
+      };
+
+      const unsubscribeRootSignal = rootSignal.subscribe(updateFromRoot);
+      const unsubscribeRootStaleSignal = rootSignal.staleSignal?.subscribe(isStale => {
+        if (isStale) {
+          innerSetter = null;
+          markDownstreamStale();
+        } else {
+          updateFromRoot();
         }
       });
-    } else {
-      subscribeToInnerSignal(rootSignal.get());
-    }
-    return () => {
-      cancelInnerFreshnessWait?.();
-      unsubscribeInnerSignal?.();
-      innerSetter = null;
-      cancelRootFreshnessWait?.();
-      unsubscribeRootSignal();
-    };
-  });
+      updateFromRoot();
+
+      return () => {
+        unsubscribeInner();
+        unsubscribeRootStaleSignal?.();
+        unsubscribeRootSignal();
+      };
+    },
+  );
   return [signal, setter] as const;
 }

--- a/packages/lms-common/src/flattenSignal.ts
+++ b/packages/lms-common/src/flattenSignal.ts
@@ -41,19 +41,18 @@ export function flattenSignalOfSignal<TInner>(
           return;
         }
 
-        /** Applies an inner update only when both levels say its value is fresh. */
+        /** Applies an inner update only when both levels are fresh. */
         const updateFromInner = (
           value: TInner | NotAvailable,
           patches?: Array<Patch>,
           tags?: Array<WriteTag>,
-          isFresh = maybeInnerSignal.staleSignal?.get() !== true,
         ) => {
-          if (rootSignal.staleSignal?.get() === true || !isFresh) {
-            markDownstreamStale();
-            return;
-          }
-          if (!isAvailable(value)) {
-            markDownstreamStale();
+          if (
+            rootSignal.staleSignal?.get() === true ||
+            maybeInnerSignal.staleSignal?.get() === true ||
+            !isAvailable(value)
+          ) {
+            markDownstreamStale(tags);
           } else if (patches === undefined) {
             setDownstream(value, tags);
           } else {
@@ -61,15 +60,11 @@ export function flattenSignalOfSignal<TInner>(
           }
         };
 
-        unsubscribeInnerSignal =
-          maybeInnerSignal.subscribeFullWithFreshness?.(updateFromInner) ??
-          maybeInnerSignal.subscribeFull(updateFromInner);
+        unsubscribeInnerSignal = maybeInnerSignal.subscribeFull(updateFromInner);
         unsubscribeInnerStaleSignal =
           maybeInnerSignal.staleSignal?.subscribe(isStale => {
             if (isStale) {
               markDownstreamStale();
-            } else {
-              updateFromInner(maybeInnerSignal.get());
             }
           }) ?? null;
         updateFromInner(maybeInnerSignal.get());
@@ -88,8 +83,6 @@ export function flattenSignalOfSignal<TInner>(
       const unsubscribeRootStaleSignal = rootSignal.staleSignal?.subscribe(isStale => {
         if (isStale) {
           markDownstreamStale();
-        } else {
-          updateFromRoot();
         }
       });
       updateFromRoot();
@@ -155,16 +148,19 @@ export function flattenSignalOfWritableSignal<TInner>(
           return;
         }
 
-        /** Applies an inner update only when both levels say its value is fresh. */
+        /** Applies an inner update only when both levels are fresh. */
         const maybeUpdateDownstream = (
           value: TInner | NotAvailable,
           patches?: Array<Patch>,
           tags?: Array<WriteTag>,
-          isFresh = maybeInnerSignal[0].staleSignal?.get() !== true,
         ) => {
-          if (rootSignal.staleSignal?.get() === true || !isFresh || !isAvailable(value)) {
+          if (
+            rootSignal.staleSignal?.get() === true ||
+            maybeInnerSignal[0].staleSignal?.get() === true ||
+            !isAvailable(value)
+          ) {
             innerSetter = null;
-            markDownstreamStale();
+            markDownstreamStale(tags);
             return;
           }
           if (patches !== undefined) {
@@ -203,16 +199,12 @@ export function flattenSignalOfWritableSignal<TInner>(
           innerSetter = setter;
         };
 
-        unsubscribeInnerSignal =
-          maybeInnerSignal[0].subscribeFullWithFreshness?.(maybeUpdateDownstream) ??
-          maybeInnerSignal[0].subscribeFull(maybeUpdateDownstream);
+        unsubscribeInnerSignal = maybeInnerSignal[0].subscribeFull(maybeUpdateDownstream);
         unsubscribeInnerStaleSignal =
           maybeInnerSignal[0].staleSignal?.subscribe(isStale => {
             if (isStale) {
               innerSetter = null;
               markDownstreamStale();
-            } else {
-              maybeUpdateDownstream(maybeInnerSignal[0].get());
             }
           }) ?? null;
         maybeUpdateDownstream(maybeInnerSignal[0].get());
@@ -233,8 +225,6 @@ export function flattenSignalOfWritableSignal<TInner>(
         if (isStale) {
           innerSetter = null;
           markDownstreamStale();
-        } else {
-          updateFromRoot();
         }
       });
       updateFromRoot();

--- a/packages/lms-common/src/flattenSignal.ts
+++ b/packages/lms-common/src/flattenSignal.ts
@@ -41,16 +41,14 @@ export function flattenSignalOfSignal<TInner>(
           return;
         }
 
+        /** Applies an inner update only when both levels say its value is fresh. */
         const updateFromInner = (
           value: TInner | NotAvailable,
           patches?: Array<Patch>,
           tags?: Array<WriteTag>,
+          isFresh = maybeInnerSignal.staleSignal?.get() !== true,
         ) => {
-          // Full updates restore inner freshness and include patches, while get() snapshots do not.
-          if (
-            rootSignal.staleSignal?.get() === true ||
-            (patches === undefined && maybeInnerSignal.staleSignal?.get() === true)
-          ) {
+          if (rootSignal.staleSignal?.get() === true || !isFresh) {
             markDownstreamStale();
             return;
           }
@@ -63,14 +61,17 @@ export function flattenSignalOfSignal<TInner>(
           }
         };
 
-        unsubscribeInnerSignal = maybeInnerSignal.subscribeFull(updateFromInner);
-        unsubscribeInnerStaleSignal = maybeInnerSignal.staleSignal?.subscribe(isStale => {
-          if (isStale) {
-            markDownstreamStale();
-          } else {
-            updateFromInner(maybeInnerSignal.get());
-          }
-        }) ?? null;
+        unsubscribeInnerSignal =
+          maybeInnerSignal.subscribeFullWithFreshness?.(updateFromInner) ??
+          maybeInnerSignal.subscribeFull(updateFromInner);
+        unsubscribeInnerStaleSignal =
+          maybeInnerSignal.staleSignal?.subscribe(isStale => {
+            if (isStale) {
+              markDownstreamStale();
+            } else {
+              updateFromInner(maybeInnerSignal.get());
+            }
+          }) ?? null;
         updateFromInner(maybeInnerSignal.get());
       };
 
@@ -154,17 +155,14 @@ export function flattenSignalOfWritableSignal<TInner>(
           return;
         }
 
+        /** Applies an inner update only when both levels say its value is fresh. */
         const maybeUpdateDownstream = (
           value: TInner | NotAvailable,
           patches?: Array<Patch>,
           tags?: Array<WriteTag>,
+          isFresh = maybeInnerSignal[0].staleSignal?.get() !== true,
         ) => {
-          // Full updates restore inner freshness and include patches, while get() snapshots do not.
-          if (
-            rootSignal.staleSignal?.get() === true ||
-            (patches === undefined && maybeInnerSignal[0].staleSignal?.get() === true) ||
-            !isAvailable(value)
-          ) {
+          if (rootSignal.staleSignal?.get() === true || !isFresh || !isAvailable(value)) {
             innerSetter = null;
             markDownstreamStale();
             return;
@@ -205,15 +203,18 @@ export function flattenSignalOfWritableSignal<TInner>(
           innerSetter = setter;
         };
 
-        unsubscribeInnerSignal = maybeInnerSignal[0].subscribeFull(maybeUpdateDownstream);
-        unsubscribeInnerStaleSignal = maybeInnerSignal[0].staleSignal?.subscribe(isStale => {
-          if (isStale) {
-            innerSetter = null;
-            markDownstreamStale();
-          } else {
-            maybeUpdateDownstream(maybeInnerSignal[0].get());
-          }
-        }) ?? null;
+        unsubscribeInnerSignal =
+          maybeInnerSignal[0].subscribeFullWithFreshness?.(maybeUpdateDownstream) ??
+          maybeInnerSignal[0].subscribeFull(maybeUpdateDownstream);
+        unsubscribeInnerStaleSignal =
+          maybeInnerSignal[0].staleSignal?.subscribe(isStale => {
+            if (isStale) {
+              innerSetter = null;
+              markDownstreamStale();
+            } else {
+              maybeUpdateDownstream(maybeInnerSignal[0].get());
+            }
+          }) ?? null;
         maybeUpdateDownstream(maybeInnerSignal[0].get());
       };
 


### PR DESCRIPTION
Explicitly keep track of signal freshness. Fixes the bug where system prompt may sometimes not apply. Tested around the app and no regressions found.

Did two reviews. Both indicated no findings.