### PR TITLE
Add MLX disk cache config

### DIFF
--- a/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
@@ -240,6 +240,10 @@ function kvConfigToLLMMlxLoadModelConfig(
   if (maxParallelPredictions !== undefined) {
     result.maxParallelPredictions = maxParallelPredictions;
   }
+  const mlxDiskCache = parsed.get("mlx.diskCache");
+  if (mlxDiskCache !== undefined) {
+    result.mlxDiskCache = mlxDiskCache;
+  }
   const mlxKvCacheQuantization = parsed.get("mlx.kvCacheQuantization");
   if (mlxKvCacheQuantization !== undefined) {
     result.mlxKvCacheQuantization = mlxKvCacheQuantization.enabled ? mlxKvCacheQuantization : false;
@@ -306,6 +310,7 @@ export function llmLoadModelConfigToKVConfig(config: LLMLoadModelConfig): KVConf
       config.llamaVCacheQuantizationType,
       "f16",
     ),
+    "mlx.diskCache": config.mlxDiskCache,
     "mlx.kvCacheQuantization": maybeFalseValueToValue(config.mlxKvCacheQuantization, {
       enabled: false,
       bits: 8,

--- a/packages/lms-kv-config/src/schema.test.ts
+++ b/packages/lms-kv-config/src/schema.test.ts
@@ -560,10 +560,13 @@ describe("globalConfigSchematics", () => {
     ).not.toHaveProperty("autoFit");
   });
 
-  it("defaults MLX prompt disk caching on and preserves explicit overrides", () => {
+  it("marks MLX prompt disk caching as machine-dependent and preserves explicit overrides", () => {
     const emptyConfig = makeKVConfigFromFields([]);
     const disabledDiskCacheConfig = llmLoadModelConfigToKVConfig({ mlxDiskCache: false });
 
+    expect(
+      globalConfigSchematics.getValueTypeParamByFullKey("llm.load.mlx.diskCache").machineDependent,
+    ).toBe(true);
     expect(globalConfigSchematics.access(emptyConfig, "llm.load.mlx.diskCache")).toBe(true);
     expect(llmMlxLoadConfigSchematics.access(disabledDiskCacheConfig, "mlx.diskCache")).toBe(false);
     expect(

--- a/packages/lms-kv-config/src/schema.test.ts
+++ b/packages/lms-kv-config/src/schema.test.ts
@@ -560,6 +560,17 @@ describe("globalConfigSchematics", () => {
     ).not.toHaveProperty("autoFit");
   });
 
+  it("defaults MLX prompt disk caching on and preserves explicit overrides", () => {
+    const emptyConfig = makeKVConfigFromFields([]);
+    const disabledDiskCacheConfig = llmLoadModelConfigToKVConfig({ mlxDiskCache: false });
+
+    expect(globalConfigSchematics.access(emptyConfig, "llm.load.mlx.diskCache")).toBe(true);
+    expect(llmMlxLoadConfigSchematics.access(disabledDiskCacheConfig, "mlx.diskCache")).toBe(false);
+    expect(
+      kvConfigToLLMLoadModelConfig(disabledDiskCacheConfig, { modelFormat: "safetensors" }),
+    ).toMatchObject({ mlxDiskCache: false });
+  });
+
   it("uses 2048 as the default llama eval batch size", () => {
     const emptyConfig = makeKVConfigFromFields([]);
 

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -472,6 +472,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
       .scope("mlx", builder =>
         builder
           .field("autoFit", "boolean", { machineDependent: true }, true)
+          .field("diskCache", "boolean", {}, true)
           .field(
             "kvCacheQuantization",
             "mlxKvCacheQuantizationType",

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -472,7 +472,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
       .scope("mlx", builder =>
         builder
           .field("autoFit", "boolean", { machineDependent: true }, true)
-          .field("diskCache", "boolean", {}, true)
+          .field("diskCache", "boolean", { machineDependent: true }, true)
           .field(
             "kvCacheQuantization",
             "mlxKvCacheQuantizationType",

--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -727,6 +727,12 @@ export interface LLMLoadModelConfig {
   llamaVCacheQuantizationType?: LLMLlamaCacheQuantizationType | false;
 
   /**
+   * Whether MLX should store reusable prompt states on disk. Disable this to keep prompt caching
+   * in memory only.
+   */
+  mlxDiskCache?: boolean;
+
+  /**
    * Quantization settings for the MLX model's key-value cache.
    *
    * Similar to Llama cache quantization, this option allows for reducing the precision of the
@@ -778,6 +784,7 @@ export const llmLoadModelConfigSchema = z
       .enum(llmLlamaCacheQuantizationTypes)
       .or(z.literal(false))
       .optional(),
+    mlxDiskCache: z.boolean().optional(),
     mlxKvCacheQuantization: llmMlxKvCacheQuantizationSchema.or(z.literal(false)).optional(),
   })
   .superRefine((config, context) => {


### PR DESCRIPTION
Adds the MLX prompt disk-cache load setting to the public configuration schema, defaulting it to enabled while preserving explicit opt-outs.